### PR TITLE
fix (doc): add missing comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Render the tree data structure.
 ```jsx
 const data = {
   id: "A",
-  name: "Root"
+  name: "Root",
   children: [
     { id: "B", name: "Node 1" },
     { id: "C", name: "Node 2" },


### PR DESCRIPTION
The example in the doc has a syntax error because of a missing comma. The PR adds that.