### PR TITLE
Id for Drop Cursor

### DIFF
--- a/packages/react-arborist/src/components/drop-cursor.tsx
+++ b/packages/react-arborist/src/components/drop-cursor.tsx
@@ -39,9 +39,9 @@ const circleStyle = {
 
 function DefaultCursor({ style }: { style: CSSProperties }) {
   return (
-    <div style={{ ...placeholderStyle, ...style }}>
-      <div style={{ ...circleStyle }}></div>
-      <div style={{ ...lineStyle }}></div>
+    <div id="arborist-drop-cursor-wrapper" style={{ ...placeholderStyle, ...style }}>
+      <div id="arborist-drop-cursor-circle" style={{ ...circleStyle }}></div>
+      <div id="arborist-drop-cursor-line" style={{ ...lineStyle }}></div>
     </div>
   );
 }


### PR DESCRIPTION
Amazing work! It looks like from an issue that you might extend how to use the Drop Cursor, but in the meantime, adding a unique ID so we can override styles with css. 