### PR TITLE
Update width/height type to allow strings

### DIFF
--- a/packages/react-arborist/src/types/tree-props.ts
+++ b/packages/react-arborist/src/types/tree-props.ts
@@ -26,8 +26,8 @@ export interface TreeProps<T> {
 
   /* Sizes */
   rowHeight?: number;
-  width?: number;
-  height?: number;
+  width?: number | string;
+  height?: number | string;
   indent?: number;
   paddingTop?: number;
   paddingBottom?: number;

--- a/packages/react-arborist/src/types/tree-props.ts
+++ b/packages/react-arborist/src/types/tree-props.ts
@@ -27,7 +27,7 @@ export interface TreeProps<T> {
   /* Sizes */
   rowHeight?: number;
   width?: number | string;
-  height?: number | string;
+  height?: number;
   indent?: number;
   paddingTop?: number;
   paddingBottom?: number;


### PR DESCRIPTION
When defining the width of my Tree I want to be able to take it 100% of the width. Now TypeScript will tell me only numbers are allowed even though strings work fine. ReactArborist uses FixedSizeList from react-window as seen here: https://github.com/brimdata/react-arborist/blob/fb7333811f167b8f695269668a16c55e82e86882/packages/react-arborist/src/components/default-container.tsx#L220 React-window docs tell us width can be a number or string: https://react-window.vercel.app/#/api/FixedSizeList