### PR TITLE
Feature: Single selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ interface TreeProps<T> {
   /* Config */
   openByDefault?: boolean;
   selectionFollowsFocus?: boolean;
-  disableMultipleSelections?: boolean;
+  disableMultiSelection?: boolean;
   disableDrag?: string | boolean | BoolFunc<T>;
   disableDrop?: string | boolean | BoolFunc<T>;
   childrenAccessor?: string | ((d: T) => T[]);

--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ interface TreeProps<T> {
   /* Config */
   openByDefault?: boolean;
   selectionFollowsFocus?: boolean;
+  disableMultipleSelections?: boolean;
   disableDrag?: string | boolean | BoolFunc<T>;
   disableDrop?: string | boolean | BoolFunc<T>;
   childrenAccessor?: string | ((d: T) => T[]);

--- a/packages/react-arborist/src/components/default-container.tsx
+++ b/packages/react-arborist/src/components/default-container.tsx
@@ -76,7 +76,11 @@ export function DefaultContainer() {
         if (e.key === "ArrowDown") {
           e.preventDefault();
           const next = tree.nextNode;
-          if (!e.shiftKey || tree.props.disableMultiSelection) {
+          if (e.metaKey) {
+            tree.select(tree.focusedNode);
+            tree.activate(tree.focusedNode);
+            return;
+          } else if (!e.shiftKey || tree.props.disableMultiSelection) {
             tree.focus(next);
             return;
           } else {
@@ -179,12 +183,6 @@ export function DefaultContainer() {
           const node = tree.focusedNode;
           if (!node) return;
           tree.openSiblings(node);
-          return;
-        }
-        if (e.key === "ArrowDown" && e.metaKey) {
-          e.preventDefault();
-          tree.select(tree.focusedNode);
-          tree.activate(tree.focusedNode);
           return;
         }
         if (e.key === "PageUp") {

--- a/packages/react-arborist/src/components/default-container.tsx
+++ b/packages/react-arborist/src/components/default-container.tsx
@@ -73,44 +73,43 @@ export function DefaultContainer() {
           focusPrevElement(e.currentTarget);
           return;
         }
-        if (e.key === "ArrowDown" && !e.shiftKey && !e.metaKey) {
+        if (e.key === "ArrowDown") {
           e.preventDefault();
           const next = tree.nextNode;
-          tree.focus(next);
-          return;
-        }
-        if (e.key === "ArrowDown" && e.shiftKey) {
-          e.preventDefault();
-          const next = tree.nextNode;
-          if (!next) return;
-          const current = tree.focusedNode;
-          if (!current) {
-            tree.focus(tree.firstNode);
-          } else if (current.isSelected) {
-            tree.selectContiguous(next);
+          if (!e.shiftKey || tree.props.disableMultiSelection) {
+            tree.focus(next);
+            return;
           } else {
-            tree.selectMulti(next);
+            if (!next) return;
+            const current = tree.focusedNode;
+            if (!current) {
+              tree.focus(tree.firstNode);
+            } else if (current.isSelected) {
+              tree.selectContiguous(next);
+            } else {
+              tree.selectMulti(next);
+            }
+            return;
           }
-          return;
         }
-        if (e.key === "ArrowUp" && !e.shiftKey) {
-          e.preventDefault();
-          tree.focus(tree.prevNode);
-          return;
-        }
-        if (e.key === "ArrowUp" && e.shiftKey) {
+        if (e.key === "ArrowUp") {
           e.preventDefault();
           const prev = tree.prevNode;
-          const current = tree.focusedNode;
-          if (!prev) return;
-          if (!current) {
-            tree.focus(tree.lastNode); // ?
-          } else if (current.isSelected) {
-            tree.selectContiguous(prev);
+          if (!e.shiftKey || tree.props.disableMultiSelection) {
+            tree.focus(prev);
+            return;
           } else {
-            tree.selectMulti(prev);
+            if (!prev) return;
+            const current = tree.focusedNode;
+            if (!current) {
+              tree.focus(tree.lastNode); // ?
+            } else if (current.isSelected) {
+              tree.selectContiguous(prev);
+            } else {
+              tree.selectMulti(prev);
+            }
+            return;
           }
-          return;
         }
         if (e.key === "ArrowRight") {
           const node = tree.focusedNode;

--- a/packages/react-arborist/src/interfaces/node-api.ts
+++ b/packages/react-arborist/src/interfaces/node-api.ts
@@ -186,9 +186,9 @@ export class NodeApi<T = any> {
   }
 
   handleClick = (e: React.MouseEvent) => {
-    if (e.metaKey) {
+    if (e.metaKey && !this.tree.props.disableMultiSelection) {
       this.isSelected ? this.deselect() : this.selectMulti();
-    } else if (e.shiftKey) {
+    } else if (e.shiftKey && !this.tree.props.disableMultiSelection) {
       this.selectContiguous();
     } else {
       this.select();

--- a/packages/react-arborist/src/interfaces/tree-api.ts
+++ b/packages/react-arborist/src/interfaces/tree-api.ts
@@ -338,6 +338,7 @@ export class TreeApi<T> {
   }
 
   selectMulti(identity: Identity) {
+    if (this.props.disableMultipleSelections) return this.select(identity);
     const node = this.get(identifyNull(identity));
     if (!node) return;
     this.dispatch(focus(node.id));
@@ -350,6 +351,7 @@ export class TreeApi<T> {
   }
 
   selectContiguous(identity: Identity) {
+    if (this.props.disableMultipleSelections) return this.select(identity);
     if (!identity) return;
     const id = identify(identity);
     const { anchor, mostRecent } = this.state.nodes.selection;

--- a/packages/react-arborist/src/interfaces/tree-api.ts
+++ b/packages/react-arborist/src/interfaces/tree-api.ts
@@ -338,7 +338,6 @@ export class TreeApi<T> {
   }
 
   selectMulti(identity: Identity) {
-    if (this.props.disableMultiSelection) return this.select(identity);
     const node = this.get(identifyNull(identity));
     if (!node) return;
     this.dispatch(focus(node.id));
@@ -351,7 +350,6 @@ export class TreeApi<T> {
   }
 
   selectContiguous(identity: Identity) {
-    if (this.props.disableMultiSelection) return this.select(identity);
     if (!identity) return;
     const id = identify(identity);
     const { anchor, mostRecent } = this.state.nodes.selection;

--- a/packages/react-arborist/src/interfaces/tree-api.ts
+++ b/packages/react-arborist/src/interfaces/tree-api.ts
@@ -338,7 +338,7 @@ export class TreeApi<T> {
   }
 
   selectMulti(identity: Identity) {
-    if (this.props.disableMultipleSelections) return this.select(identity);
+    if (this.props.disableMultiSelection) return this.select(identity);
     const node = this.get(identifyNull(identity));
     if (!node) return;
     this.dispatch(focus(node.id));
@@ -351,7 +351,7 @@ export class TreeApi<T> {
   }
 
   selectContiguous(identity: Identity) {
-    if (this.props.disableMultipleSelections) return this.select(identity);
+    if (this.props.disableMultiSelection) return this.select(identity);
     if (!identity) return;
     const id = identify(identity);
     const { anchor, mostRecent } = this.state.nodes.selection;

--- a/packages/react-arborist/src/types/tree-props.ts
+++ b/packages/react-arborist/src/types/tree-props.ts
@@ -36,7 +36,7 @@ export interface TreeProps<T> {
   /* Config */
   openByDefault?: boolean;
   selectionFollowsFocus?: boolean;
-  disableMultipleSelections?: boolean;
+  disableMultiSelection?: boolean;
   disableDrag?: string | boolean | BoolFunc<T>;
   disableDrop?: string | boolean | BoolFunc<T>;
   childrenAccessor?: string | ((d: T) => T[] | null);

--- a/packages/react-arborist/src/types/tree-props.ts
+++ b/packages/react-arborist/src/types/tree-props.ts
@@ -36,6 +36,7 @@ export interface TreeProps<T> {
   /* Config */
   openByDefault?: boolean;
   selectionFollowsFocus?: boolean;
+  disableMultipleSelections?: boolean;
   disableDrag?: string | boolean | BoolFunc<T>;
   disableDrop?: string | boolean | BoolFunc<T>;
   childrenAccessor?: string | ((d: T) => T[] | null);


### PR DESCRIPTION
Hey @jameskerr, thanks for your work on the library! 2.0 came out right before we had a use-case for it and it's been such a great foundation so far.

When following a master/detail pattern around the tree, I've found myself immediately relying on the focus state rather than the selection one to avoid multi-selected states (since they don't make sense in our use-case). What do you think of a prop to disable multi-selection?