### PR TITLE
Prevent scrolling to nodes on scroll

### DIFF
--- a/packages/react-arborist/src/components/row-container.tsx
+++ b/packages/react-arborist/src/components/row-container.tsx
@@ -66,8 +66,8 @@ export const RowContainer = React.memo(function RowContainer<T>({
   };
 
   useEffect(() => {
-    if (!node.isEditing && node.isFocused && tree.focusedNode !== node) {
-      el.current?.focus();
+    if (!node.isEditing && node.isFocused) {
+      el.current?.focus({ preventScroll: true });
     }
   }, [node.isEditing, node.isFocused, el.current]);
 

--- a/packages/react-arborist/src/components/row-container.tsx
+++ b/packages/react-arborist/src/components/row-container.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { useDataUpdates, useNodesContext, useTreeApi } from "../context";
 import { useDragHook } from "../dnd/drag-hook";
 import { useDropHook } from "../dnd/drop-hook";
-import { IdObj } from "../types/utils";
 import { useFreshNode } from "../hooks/use-fresh-node";
 
 type Props = {
@@ -67,7 +66,7 @@ export const RowContainer = React.memo(function RowContainer<T>({
   };
 
   useEffect(() => {
-    if (!node.isEditing && node.isFocused) {
+    if (!node.isEditing && node.isFocused && tree.focusedNode !== node) {
       el.current?.focus();
     }
   }, [node.isEditing, node.isFocused, el.current]);


### PR DESCRIPTION
Closes #75 

The understanding is that RowContainer mounts/unmounts upon scrolling in and out of view since the list of nodes is virtualized. The RowContainer's useEffect for handling a focus event triggers on mount, causing the node to be focused and the scroll position to jump.

This change prevents scroll upon focusing which prevents the unintended jumping.

_NOTE: This solves the scroll bug, but without tests, I can't confidently say this hasn't introduced a regression. Would appreciate some help/guidance on testing_