### PR TITLE
Yarn Start Script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   ],
   "scripts": {
     "bump": "yarn workspace react-arborist version",
-    "dev:shocase": "yarn workspace showcase dev",
-    "dev:library": "yarn workspace react-arborist watch",
-    "dev": "run-p 'dev:**'",
+    "start:showcase": "yarn workspace showcase dev",
+    "start:library": "yarn workspace react-arborist watch",
+    "start": "run-p 'start:**'",
     "build": "yarn workspace react-arborist build",
     "watch": "yarn workspace react-arborist watch",
     "build:showcase": "yarn build && yarn workspace showcase build"

--- a/packages/react-arborist/src/interfaces/tree-api.ts
+++ b/packages/react-arborist/src/interfaces/tree-api.ts
@@ -479,7 +479,7 @@ export class TreeApi<T> {
         this.list.current?.scrollToItem(index, align);
       })
       .catch(() => {
-        console.log(`Id: ${id} never appeared in the list.`);
+        // Id: ${id} never appeared in the list.
       });
   }
 


### PR DESCRIPTION
* Change the script from `yarn dev` to `yarn start`.
* Remove a console.log when the tree can't find the current item to highlight/scroll to.