### PR TITLE
Fix the tree background color for the cities demo

### DIFF
--- a/packages/showcase/styles/cities.module.css
+++ b/packages/showcase/styles/cities.module.css
@@ -213,5 +213,10 @@
     .mobileWarning {
         display: block;
     }
-  }
+}
   
+@media (prefers-color-scheme: dark) {
+    .tree {
+        background: #101010;
+    }
+}

--- a/packages/showcase/styles/cities.module.css
+++ b/packages/showcase/styles/cities.module.css
@@ -219,4 +219,8 @@
     .tree {
         background: #101010;
     }
+
+    .row:focus-visible .node {
+        color: black;
+    }
 }


### PR DESCRIPTION
Because the `globals.css` contains a media query setting the body text and background colors for `prefers-color-scheme: dark`, the tree on this demo becomes unreadable for "dark mode" users

(to test in chrome, dev tools, ctrl+shift+p > emulate dark)

before
![before](https://user-images.githubusercontent.com/28578847/211140839-e6d3596c-7ec1-4d5d-90b9-2ddc4b14b5c3.png)

after
![after](https://user-images.githubusercontent.com/28578847/211140849-b6d08bf5-7723-4756-8e60-35216e848447.png)