### PR TITLE
Fix for when pressing the 'a' key and onCreate is not defined

### DIFF
--- a/packages/react-arborist/src/components/default-container.tsx
+++ b/packages/react-arborist/src/components/default-container.tsx
@@ -137,8 +137,7 @@ export function DefaultContainer() {
           tree.selectAll();
           return;
         }
-        if (e.key === "a" && !e.metaKey) {
-          if (!tree.props.onCreate) return;
+        if (e.key === "a" && !e.metaKey && tree.props.onCreate) {
           tree.createLeaf();
           return;
         }


### PR DESCRIPTION
Closes: https://github.com/brimdata/react-arborist/issues/85

This is a temporary fix to make focus search work for controlled trees without `onCreate` defined, before https://github.com/brimdata/react-arborist/pull/76 is implemented.
