### PR TITLE
Add prop to pass overscanCount to react-window

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ function App() {
       height={1000}
       indent={24}
       rowHeight={36}
+      overscanCount={1}
       paddingTop={30}
       paddingBottom={10}
       padding={25 /* sets both */}
@@ -281,6 +282,7 @@ interface TreeProps<T> {
 
   /* Sizes */
   rowHeight?: number;
+  overscanCount?: number;
   width?: number;
   height?: number;
   indent?: number;

--- a/packages/react-arborist/src/components/default-container.tsx
+++ b/packages/react-arborist/src/components/default-container.tsx
@@ -221,6 +221,7 @@ export function DefaultContainer() {
         height={tree.height}
         width={tree.width}
         itemSize={tree.rowHeight}
+        overscanCount={tree.overscanCount}
         itemKey={(index) => tree.visibleNodes[index]?.id || index}
         outerElementType={ListOuterElement}
         innerElementType={ListInnerElement}

--- a/packages/react-arborist/src/interfaces/tree-api.ts
+++ b/packages/react-arborist/src/interfaces/tree-api.ts
@@ -83,6 +83,10 @@ export class TreeApi<T> {
     return this.props.rowHeight ?? 24;
   }
 
+  get overscanCount() {
+    return this.props.overscanCount ?? 1;
+  }
+
   get searchTerm() {
     return (this.props.searchTerm || "").trim();
   }

--- a/packages/react-arborist/src/types/tree-props.ts
+++ b/packages/react-arborist/src/types/tree-props.ts
@@ -26,6 +26,7 @@ export interface TreeProps<T> {
 
   /* Sizes */
   rowHeight?: number;
+  overscanCount?: number;
   width?: number | string;
   height?: number;
   indent?: number;


### PR DESCRIPTION
Closes: https://github.com/brimdata/react-arborist/issues/83

This adds the prop `overscanCount` to the Tree where the user can change the number of nodes rendered but not visible