### PR TITLE
disabledDrop and target/source drop monitoring #62

### DIFF
--- a/packages/react-arborist/src/dnd/drop-hook.ts
+++ b/packages/react-arborist/src/dnd/drop-hook.ts
@@ -33,12 +33,17 @@ export function useDropHook(
         });
         if (!drop) return false;
         const dropParent = tree.get(drop.parentId) ?? tree.root;
-
-        for (let id of item.dragIds) {
-          const drag = tree.get(id);
+        
+        const dragNodes = <NodeApi[]>item.dragIds.map(tree.get, tree);
+        for (const drag of dragNodes) {
           if (!drag) return false;
           if (!dropParent) return false;
           if (drag.isInternal && isDecendent(dropParent, drag)) return false;
+        }
+
+        const check = tree.props.disableDrop;
+        if (typeof check === 'function' && check(dropParent, dragNodes)) {
+          return false;
         }
         return true;
       },

--- a/packages/react-arborist/src/types/tree-props.ts
+++ b/packages/react-arborist/src/types/tree-props.ts
@@ -40,7 +40,7 @@ export interface TreeProps<T> {
   disableMultiSelection?: boolean;
   disableEdit?: string | boolean | BoolFunc<T>;
   disableDrag?: string | boolean | BoolFunc<T>;
-  disableDrop?: string | boolean | BoolFunc<T>;
+  disableDrop?: string | boolean | BoolFunc<T> | ((node: NodeApi, dragNodes: NodeApi[]) => boolean);
   childrenAccessor?: string | ((d: T) => T[] | null);
   idAccessor?: string | ((d: T) => string);
 


### PR DESCRIPTION
This pull request is for the feature that allows users to disable the ability to drop a dragged item on a specific target at runtime.