### PR TITLE
Add support for external dragDropManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ interface TreeProps<T> {
   dndRootElement?: globalThis.Node | null;
   onClick?: MouseEventHandler;
   onContextMenu?: MouseEventHandler;
+  dragDropManager?: DragDropManager
 }
 ```
 

--- a/packages/react-arborist/src/components/provider.tsx
+++ b/packages/react-arborist/src/components/provider.tsx
@@ -86,6 +86,7 @@ export function TreeProvider<T>({
             <DndProvider
               backend={HTML5Backend}
               options={{ rootElement: api.props.dndRootElement || undefined }}
+              manager={treeProps.dragDropManager}
             >
               {children}
             </DndProvider>

--- a/packages/react-arborist/src/components/provider.tsx
+++ b/packages/react-arborist/src/components/provider.tsx
@@ -86,7 +86,7 @@ export function TreeProvider<T>({
             <DndProvider
               backend={HTML5Backend}
               options={{ rootElement: api.props.dndRootElement || undefined }}
-              manager={treeProps.dragDropManager}
+              {...(treeProps.dragDropManager && { manager: treeProps.dragDropManager })}
             >
               {children}
             </DndProvider>

--- a/packages/react-arborist/src/types/tree-props.ts
+++ b/packages/react-arborist/src/types/tree-props.ts
@@ -5,6 +5,7 @@ import { ElementType, MouseEventHandler } from "react";
 import { ListOnScrollProps } from "react-window";
 import { NodeApi } from "../interfaces/node-api";
 import { OpenMap } from "../state/open-slice";
+import { useDragDropManager } from "react-dnd"
 
 export interface TreeProps<T> {
   /* Data Options */
@@ -75,4 +76,6 @@ export interface TreeProps<T> {
   dndRootElement?: globalThis.Node | null;
   onClick?: MouseEventHandler;
   onContextMenu?: MouseEventHandler;
+
+  dragDropManager?: ReturnType<typeof useDragDropManager>
 }


### PR DESCRIPTION
add external dragdropmanager to allow drag to external target.

Note: this minimal changes don't support internal dnd and external dnd exist at the same time (e.g. vscode explorer). we need to do following changes for this feature:
1. allow user disable ```useDragHook``` in ```RowContainer```
2. allow user change the dnd type from "NODE" to another string
3. expose ```useDragHook``` to users
4. add custom data to useDragHook to allow users attach custom data during dnd.

I don't have suitable code to test this, so these changes aren't included in this pull request.