### PR TITLE
Add preview ref api for Node

### DIFF
--- a/packages/react-arborist/src/components/drag-preview-container.tsx
+++ b/packages/react-arborist/src/components/drag-preview-container.tsx
@@ -1,5 +1,5 @@
 import { useDragLayer } from "react-dnd";
-import { useDndContext, useTreeApi } from "../context";
+import { useTreeApi } from "../context";
 import { DefaultDragPreview } from "./default-drag-preview";
 
 export function DragPreviewContainer() {

--- a/packages/react-arborist/src/components/row-container.tsx
+++ b/packages/react-arborist/src/components/row-container.tsx
@@ -35,7 +35,7 @@ export const RowContainer = React.memo(function RowContainer<T>({
   const node = useFreshNode<T>(index);
 
   const el = useRef<HTMLDivElement | null>(null);
-  const dragRef = useDragHook<T>(node);
+  const { dragRef, previewRef } = useDragHook<T>(node);
   const dropRef = useDropHook(el, node);
   const innerRef = useCallback(
     (n: any) => {
@@ -76,7 +76,7 @@ export const RowContainer = React.memo(function RowContainer<T>({
 
   return (
     <Row node={node} innerRef={innerRef} attrs={rowAttrs}>
-      <Node node={node} tree={tree} style={nodeStyle} dragHandle={dragRef} />
+      <Node node={node} tree={tree} style={nodeStyle}  dragHandle={dragRef} previewHandle={previewRef} />
     </Row>
   );
 });

--- a/packages/react-arborist/src/components/tree.tsx
+++ b/packages/react-arborist/src/components/tree.tsx
@@ -18,7 +18,7 @@ function TreeComponent<T>(
       <OuterDrop>
         <TreeContainer />
       </OuterDrop>
-      <DragPreviewContainer />
+      { props.renderDragPreview && <DragPreviewContainer /> }
     </TreeProvider>
   );
 }

--- a/packages/react-arborist/src/dnd/drag-hook.ts
+++ b/packages/react-arborist/src/dnd/drag-hook.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { ConnectDragSource, useDrag } from "react-dnd";
 import { getEmptyImage } from "react-dnd-html5-backend";
 import { useTreeApi } from "../context";
@@ -9,7 +9,7 @@ import { actions as dnd } from "../state/dnd-slice";
 import { safeRun } from "../utils";
 import { ROOT_ID } from "../data/create-root";
 
-export function useDragHook<T>(node: NodeApi<T>): ConnectDragSource {
+export function useDragHook<T>(node: NodeApi<T>) {
   const tree = useTreeApi();
   const ids = tree.selectedIds;
   const [_, ref, preview] = useDrag<DragItem, DropResult, void>(
@@ -42,10 +42,15 @@ export function useDragHook<T>(node: NodeApi<T>): ConnectDragSource {
     }),
     [ids, node]
   );
+  
+   useEffect(() => {
+    if (tree.renderDragPreview) {
+      preview(getEmptyImage());
+    }
+  }, []);
 
-  useEffect(() => {
-    preview(getEmptyImage());
-  }, [preview]);
-
-  return ref;
+  return {
+    dragRef: ref,
+    previewRef: preview,
+  };
 }

--- a/packages/react-arborist/src/interfaces/tree-api.ts
+++ b/packages/react-arborist/src/interfaces/tree-api.ts
@@ -15,7 +15,6 @@ import { createRoot, ROOT_ID } from "../data/create-root";
 import { actions as visibility } from "../state/open-slice";
 import { actions as selection } from "../state/selection-slice";
 import { actions as dnd } from "../state/dnd-slice";
-import { DefaultDragPreview } from "../components/default-drag-preview";
 import { DefaultContainer } from "../components/default-container";
 import { Cursor } from "../dnd/compute-drop";
 import { Store } from "redux";
@@ -628,7 +627,7 @@ export class TreeApi<T> {
   }
 
   get renderDragPreview() {
-    return this.props.renderDragPreview || DefaultDragPreview;
+    return this.props.renderDragPreview;
   }
 
   get renderCursor() {

--- a/packages/react-arborist/src/types/renderers.ts
+++ b/packages/react-arborist/src/types/renderers.ts
@@ -9,6 +9,7 @@ export type NodeRendererProps<T> = {
   node: NodeApi<T>;
   tree: TreeApi<T>;
   dragHandle?: (el: HTMLDivElement | null) => void;
+  previewHandle?: (el: HTMLDivElement | null) => void; 
   preview?: boolean;
 };
 


### PR DESCRIPTION
Issues

One of the phenomena of Chrome browsers on Mac is that outside the DND range, the Drag or Drop event will be delayed by 250ms, because to play the animation, react-DND uses `preview(getEmptyImage()); `. Going to overlay causes a problem: it looks stuttering

![20230321095759](https://user-images.githubusercontent.com/12042870/226501935-8eda2e9a-b1c6-4fd9-9178-6375fc7f7ac4.gif)

So the default preview was removed, the default preview was changed to react-dnd's preview, and the preview interface was exposed

![20230321100313](https://user-images.githubusercontent.com/12042870/226502485-6db75541-7792-4d73-b623-fd6ff85253c6.gif)

This feature only affects the default effect