### PR TITLE
Allow selectMulti to select offscreen nodes

### DIFF
--- a/packages/react-arborist/src/interfaces/tree-api.ts
+++ b/packages/react-arborist/src/interfaces/tree-api.ts
@@ -345,13 +345,13 @@ export class TreeApi<T> {
   }
 
   selectMulti(identity: Identity) {
-    const node = this.get(identifyNull(identity));
-    if (!node) return;
-    this.dispatch(focus(node.id));
-    this.dispatch(selection.add(node.id));
-    this.dispatch(selection.anchor(node.id));
-    this.dispatch(selection.mostRecent(node.id));
-    this.scrollTo(node);
+    if (!identity) return;
+    const id = identify(identity);
+    this.dispatch(focus(id));
+    this.dispatch(selection.add(id));
+    this.dispatch(selection.anchor(id));
+    this.dispatch(selection.mostRecent(id));
+    this.scrollTo(id);
     if (this.focusedNode) safeRun(this.props.onFocus, this.focusedNode);
     safeRun(this.props.onSelect, this.selectedNodes);
   }


### PR DESCRIPTION
Fix for #130, presenting as a PR for comment/feedback. 

@victorvianaom proposed this fix and asked:
> What's the reason for using this.get() instead of directly calling identify() for getting the id? And, is there any workaround for selecting multiple nonvisible nodes, other than modifying the lib?

It would very helpful to multiSelect nonvisible nodes. Are there any drawbacks to using this approach?
