### PR TITLE
API to prevent nodes from being selectable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Testing Locally
 
 1. Clone the repo
-2. From the root, run yarn && yarn start
-3. Visit localhost:3000
+2. From the root, run `yarn && yarn start`
+3. Visit <localhost:3000>
 
 # Running Tests
 

--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ interface TreeProps<T> {
   openByDefault?: boolean;
   selectionFollowsFocus?: boolean;
   disableMultiSelection?: boolean;
+  disableSelect?: string | boolean | BoolFunc<T>;
   disableEdit?: string | boolean | BoolFunc<T>;
   disableDrag?: string | boolean | BoolFunc<T>;
   disableDrop?:

--- a/packages/e2e/cypress/e2e/gmail-spec.cy.ts
+++ b/packages/e2e/cypress/e2e/gmail-spec.cy.ts
@@ -139,6 +139,23 @@ describe("Testing the Gmail Demo", () => {
     cy.get("@item").contains("Categories").click(); // collapses
     cy.get("@item").should("have.length", 1);
   });
+
+  it("can select inbox but not categories", () => {
+    cy.get("@item").contains("Inbox").click();
+    cy.focused().should("have.attr", "aria-selected", "true");
+    cy.get("@item").contains("Categories").click();
+    cy.focused().should("have.attr", "aria-selected", "false");
+  });
+
+  it("select all does not select categories or spam", () => {
+    cy.get("@item").contains("Inbox").click();
+    cy.focused().type("{meta}a");
+    cy.get("[aria-selected='true']")
+      .should("not.contain.text", "Categories")
+      .should("not.contain.text", "Spam")
+      .should("contain.text", "Inbox")
+      .should("have.length", TOTAL_ITEMS - 2);
+  });
 });
 
 function dragAndDrop(src: any, dst: any) {

--- a/packages/react-arborist/src/interfaces/node-api.ts
+++ b/packages/react-arborist/src/interfaces/node-api.ts
@@ -59,6 +59,10 @@ export class NodeApi<T = any> {
     return this.tree.isEditable(this.data);
   }
 
+  get isSelectable() {
+    return this.tree.isSelectable(this.data);
+  }
+
   get isEditing() {
     return this.tree.editingId === this.id;
   }

--- a/packages/react-arborist/src/interfaces/tree-api.ts
+++ b/packages/react-arborist/src/interfaces/tree-api.ts
@@ -603,8 +603,8 @@ export class TreeApi<T> {
     return this.isActionPossible(data, this.props.disableSelect);
   }
 
-  private isActionPossible(data: T, disabler: string | boolean | BoolFunc<T> | undefined = (() => false)) {
-    return !utils.access(data, disabler) ?? true;
+  private isActionPossible(data: T, disabler: string | boolean | BoolFunc<T> = (() => false)) {
+    return !utils.access(data, disabler);
   }
 
   isDragging(node: string | IdObj | null) {

--- a/packages/react-arborist/src/interfaces/tree-api.ts
+++ b/packages/react-arborist/src/interfaces/tree-api.ts
@@ -169,7 +169,7 @@ export class TreeApi<T> {
     return this.visibleNodes.slice(start, end + 1);
   }
 
-  indexOf(id: string | null | IdObj) {
+  indexOf(id: Identity) {
     const key = utils.identifyNull(id);
     if (!key) return null;
     return this.idToIndex[key];
@@ -219,7 +219,7 @@ export class TreeApi<T> {
     }
   }
 
-  async delete(node: string | IdObj | null | string[] | IdObj[]) {
+  async delete(node: Identity | string[] | IdObj[]) {
     if (!node) return;
     const idents = Array.isArray(node) ? node : [node];
     const ids = idents.map(identify);
@@ -256,7 +256,7 @@ export class TreeApi<T> {
     setTimeout(() => this.onFocus()); // Return focus to element;
   }
 
-  activate(id: string | IdObj | null) {
+  activate(id: Identity) {
     const node = this.get(identifyNull(id));
     if (!node) return;
     safeRun(this.props.onActivate, node);
@@ -403,8 +403,8 @@ export class TreeApi<T> {
 
   setSelection(args: {
     ids: (IdObj | string)[] | null;
-    anchor: IdObj | string | null;
-    mostRecent: IdObj | string | null;
+    anchor: Identity;
+    mostRecent: Identity;
   }) {
     const ids = new Set(args.ids?.map(identify));
     const anchor = identifyNull(args.anchor);
@@ -611,7 +611,7 @@ export class TreeApi<T> {
     return !utils.access(data, disabler);
   }
 
-  isDragging(node: string | IdObj | null) {
+  isDragging(node: Identity) {
     const id = identifyNull(node);
     if (!id) return false;
     return this.state.nodes.drag.id === id;
@@ -625,7 +625,7 @@ export class TreeApi<T> {
     return this.matchFn(node);
   }
 
-  willReceiveDrop(node: string | IdObj | null) {
+  willReceiveDrop(node: Identity) {
     const id = identifyNull(node);
     if (!id) return false;
     return id === this.state.nodes.drag.idWillReceiveDrop;

--- a/packages/react-arborist/src/types/tree-props.ts
+++ b/packages/react-arborist/src/types/tree-props.ts
@@ -41,6 +41,7 @@ export interface TreeProps<T> {
   openByDefault?: boolean;
   selectionFollowsFocus?: boolean;
   disableMultiSelection?: boolean;
+  disableSelect?: string | boolean | BoolFunc<T>;
   disableEdit?: string | boolean | BoolFunc<T>;
   disableDrag?: string | boolean | BoolFunc<T>;
   disableDrop?:

--- a/packages/showcase/pages/gmail.tsx
+++ b/packages/showcase/pages/gmail.tsx
@@ -79,18 +79,18 @@ export default function GmailSidebar() {
           <p>The tree is fully functional. Try the following:</p>
           <ul>
             <li>Drag the items around</li>
-            <li>Try to drag Inbox into 'Categories' (not allowed)</li>
+            <li>Try to drag Inbox into {"'"}Categories{"'"} (not allowed)</li>
             <li>Move focus with the arrow keys</li>
             <li>Toggle folders (press spacebar)</li>
             <li>
-              Rename (press enter, only allowed on items in 'Categories'
+              Rename (press enter, only allowed on items in {"'"}Categories{"'"}
               )
             </li>
             <li>Create a new item (press A)</li>
             <li>Create a new folder (press shift+A)</li>
             <li>Delete items (press delete)</li>
             <li>Select multiple items with shift or meta</li>
-            <li>'Categories' and 'Spam' cannot be selected</li>
+            <li>{"'"}Categories{"'"} and {"'"}Spam{"'"} cannot be selected</li>
             <li>
               Filter the tree by typing in this text box:{" "}
               <input

--- a/packages/showcase/pages/gmail.tsx
+++ b/packages/showcase/pages/gmail.tsx
@@ -47,6 +47,7 @@ export default function GmailSidebar() {
                   renderCursor={Cursor}
                   searchTerm={term}
                   paddingBottom={32}
+                  disableSelect={(data) => ["Categories", "Spam"].includes(data.name)}
                   disableEdit={(data) => data.readOnly}
                   disableDrop={({ parentNode, dragNodes }) => {
                     if (
@@ -78,17 +79,18 @@ export default function GmailSidebar() {
           <p>The tree is fully functional. Try the following:</p>
           <ul>
             <li>Drag the items around</li>
-            <li>Try to drag Inbox into Categories (not allowed)</li>
+            <li>Try to drag Inbox into 'Categories' (not allowed)</li>
             <li>Move focus with the arrow keys</li>
             <li>Toggle folders (press spacebar)</li>
             <li>
-              Rename (press enter, only allowed on items in {"'"}Categories{"'"}
+              Rename (press enter, only allowed on items in 'Categories'
               )
             </li>
             <li>Create a new item (press A)</li>
             <li>Create a new folder (press shift+A)</li>
             <li>Delete items (press delete)</li>
             <li>Select multiple items with shift or meta</li>
+            <li>'Categories' and 'Spam' cannot be selected</li>
             <li>
               Filter the tree by typing in this text box:{" "}
               <input


### PR DESCRIPTION
Added a tree prop `disableSelect`, in the spirit of `disableEdit` and `disableDrag`, closes #56