### PR TITLE
Added useDynamicTree hook 

### DIFF
--- a/packages/react-arborist/src/hooks/use-dynamic-tree.ts
+++ b/packages/react-arborist/src/hooks/use-dynamic-tree.ts
@@ -1,0 +1,54 @@
+import { useMemo, useState } from "react";
+import { SimpleTree } from "../data/simple-tree";
+import {
+  CreateHandler,
+  DeleteHandler,
+  MoveHandler,
+  RenameHandler,
+} from "../types/handlers";
+import { IdObj } from "../types/utils";
+
+let nextId = 0;
+
+export function useDynamicTree<T>() {
+  const [data, setData] = useState<T[]>([]);
+  const tree = useMemo(
+    () =>
+      new SimpleTree<// @ts-ignore
+      T>(data),
+    [data]
+  );
+
+  const onMove: MoveHandler<T> = (args: {
+    dragIds: string[];
+    parentId: null | string;
+    index: number;
+  }) => {
+    for (const id of args.dragIds) {
+      tree.move({ id, parentId: args.parentId, index: args.index });
+    }
+    setData(tree.data);
+  };
+
+  const onRename: RenameHandler<T> = ({ name, id }) => {
+    tree.update({ id, changes: { name } as any });
+    setData(tree.data);
+  };
+
+  const onCreate: CreateHandler<T> = ({ parentId, index, type }) => {
+    const data = { id: `simple-tree-id-${nextId++}`, name: "" } as any;
+    if (type === "internal") data.children = [];
+    tree.create({ parentId, index, data });
+    setData(tree.data);
+    return data;
+  };
+
+  const onDelete: DeleteHandler<T> = (args: { ids: string[] }) => {
+    args.ids.forEach((id) => tree.drop({ id }));
+    setData(tree.data);
+  };
+
+  const controllers = { onMove, onRename, onCreate, onDelete };
+
+  return { data, setData, controllers } as const;
+}

--- a/packages/react-arborist/src/index.ts
+++ b/packages/react-arborist/src/index.ts
@@ -7,3 +7,4 @@ export * from "./interfaces/node-api";
 export * from "./interfaces/tree-api";
 export * from "./data/simple-tree";
 export * from "./hooks/use-simple-tree";
+export * from "./hooks/use-dynamic-tree";


### PR DESCRIPTION
I added a hook that supports dynamic data. 

Currently there is a hook called useSimpleTree which keeps everything simple. It manages the tree data and provides all of the controller functions such as onCreate, onRename, onUpdate, onDelete. This makes it easy to use the tree however you have to provide initial data

I added a hook called useDynamicTree which works exactly like the simpleTree hook example it provides an option to allow us to set the data that will be used in the tree whenever we need to set it. Of course we can already use dynamic data simply by using the data prop provided in the Tree component. But what makes this hook needed is that it keeps everything simple for some of us that need to keep things simple. It provides all of the functions  just like useSimpleTree. As you may know that when using the data prop in the tree we have to add the controller functions manually. With this hook you do not need to do that. Again it makes things simple. 

Usage Example:
````
import { useDynamicTree } from "react-arborist";
import { useEffect } from "react";

function App() {
  // no need to pass anything in here just use the functions as needed
  const { data, setData, controllers } = useDynamicTree();

  useEffect(() => {
    // This would be where you make your api call or dynamic data
    const apiCall = [
      { id: "123", name: "item 1" },
      { id: "456", name: "item 2" },
    ];
    setData(apiCall);
  });

  return <Tree data={data} {...controllers} />;
}
````