### PR TITLE
Make children accessor readonly

### DIFF
--- a/packages/react-arborist/src/interfaces/tree-api.ts
+++ b/packages/react-arborist/src/interfaces/tree-api.ts
@@ -105,7 +105,7 @@ export class TreeApi<T> {
 
   accessChildren(data: T) {
     const get = this.props.childrenAccessor || "children";
-    return utils.access<T[] | undefined>(data, get) ?? null;
+    return utils.access<readonly T[] | undefined>(data, get) ?? null;
   }
 
   accessId(data: T) {

--- a/packages/react-arborist/src/types/tree-props.ts
+++ b/packages/react-arborist/src/types/tree-props.ts
@@ -36,7 +36,7 @@ export interface TreeProps<T> {
   padding?: number;
 
   /* Config */
-  childrenAccessor?: string | ((d: T) => T[] | null);
+  childrenAccessor?: string | ((d: T) => readonly T[] | null);
   idAccessor?: string | ((d: T) => string);
   openByDefault?: boolean;
   selectionFollowsFocus?: boolean;


### PR DESCRIPTION
The tree doesn't mutate the children in the data, so the accessor can return a readonly array.