### PR TITLE
Generate the list keys with the hierarchy reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,14 @@ _node_.**childIndex**
 
 Returns the node's index in relation to its siblings.
 
+_node_.**path**
+
+Returns an array that represents the ancestry of the node, starting from the root node and ending with the current node. Each element in the array corresponds to an ID in the node's hierarchy.
+
+_node_.**key**
+
+Returns the unique React key associated with the node.
+
 _node_.**next**
 
 Returns the next visible node. The node directly under this node in the tree component. Returns null if none exist.

--- a/packages/react-arborist/src/components/default-container.tsx
+++ b/packages/react-arborist/src/components/default-container.tsx
@@ -223,7 +223,7 @@ export function DefaultContainer() {
         width={tree.width}
         itemSize={tree.rowHeight}
         overscanCount={tree.overscanCount}
-        itemKey={(index) => tree.visibleNodes[index]?.key() || index}
+        itemKey={(index) => tree.visibleNodes[index]?.key || index}
         outerElementType={ListOuterElement}
         innerElementType={ListInnerElement}
         onScroll={tree.props.onScroll}

--- a/packages/react-arborist/src/components/default-container.tsx
+++ b/packages/react-arborist/src/components/default-container.tsx
@@ -223,7 +223,7 @@ export function DefaultContainer() {
         width={tree.width}
         itemSize={tree.rowHeight}
         overscanCount={tree.overscanCount}
-        itemKey={(index) => tree.visibleNodes[index]?.id || index}
+        itemKey={(index) => tree.visibleNodes[index]?.key() || index}
         outerElementType={ListOuterElement}
         innerElementType={ListInnerElement}
         onScroll={tree.props.onScroll}

--- a/packages/react-arborist/src/interfaces/node-api.ts
+++ b/packages/react-arborist/src/interfaces/node-api.ts
@@ -196,4 +196,20 @@ export class NodeApi<T = any> {
       this.activate();
     }
   };
+
+  path() {
+    const path = [this.id];
+    let parent = this.parent;
+
+    while (parent) {
+      path.push(parent.id);
+      parent = parent.parent;
+    }
+
+    return path.reverse();
+  }
+
+  key() {
+    return this.path().join(',');
+  }
 }

--- a/packages/react-arborist/src/interfaces/node-api.ts
+++ b/packages/react-arborist/src/interfaces/node-api.ts
@@ -210,6 +210,10 @@ export class NodeApi<T = any> {
   }
 
   key() {
-    return this.path().join(',');
+    if (this.id) {
+      return this.path().join(',');
+    }
+
+    return null;
   }
 }

--- a/packages/react-arborist/src/interfaces/node-api.ts
+++ b/packages/react-arborist/src/interfaces/node-api.ts
@@ -115,6 +115,26 @@ export class NodeApi<T = any> {
     }
   }
 
+  get path() {
+    const path = [this.id];
+    let parent = this.parent;
+
+    while (parent) {
+      path.push(parent.id);
+      parent = parent.parent;
+    }
+
+    return path.reverse();
+  }
+
+  get key() {
+    if (this.id) {
+      return this.path.join(',');
+    }
+
+    return null;
+  }
+
   get next(): NodeApi<T> | null {
     if (this.rowIndex === null) return null;
     return this.tree.at(this.rowIndex + 1);
@@ -196,24 +216,4 @@ export class NodeApi<T = any> {
       this.activate();
     }
   };
-
-  path() {
-    const path = [this.id];
-    let parent = this.parent;
-
-    while (parent) {
-      path.push(parent.id);
-      parent = parent.parent;
-    }
-
-    return path.reverse();
-  }
-
-  key() {
-    if (this.id) {
-      return this.path().join(',');
-    }
-
-    return null;
-  }
 }


### PR DESCRIPTION
This is a follow up to solve the issue mentioned on #175.

With this change, instead of just using the node id for the react key, two new methods were created in the Node API:

- `path()`: This method constructs an array that captures all the IDs in the node's hierarchy, from the root to the node itself.
- `key()`: The `key()` method takes the array of IDs generated by `path()` and combines them to create the actual key to be used by `react-window`'s `FixedSizeList`.

This change ensures that keys will remain unique, even in scenarios where data may contain nodes with the same ID under different parent nodes. By considering all ancestors in the key generation process, we prevent potential conflicts.

Keys will now look something like this if they are nested: `__REACT_ARBORIST_INTERNAL_ROOT__,12,15,15-1`