### PR TITLE
Fix aria-level and aria role violations

### DIFF
--- a/packages/e2e/cypress/e2e/gmail-spec.cy.ts
+++ b/packages/e2e/cypress/e2e/gmail-spec.cy.ts
@@ -64,14 +64,14 @@ describe("Testing the Gmail Demo", () => {
     cy.focused().type("a");
     cy.focused().type("Root{enter}");
     cy.get("@item").contains("Root").click();
-    cy.focused().should("have.attr", "aria-level", "0");
+    cy.focused().should("have.attr", "aria-level", "1");
 
     // On a folder that is open
     cy.get("@item").contains("Categories").click(); // opened it
     cy.focused().type("a");
     cy.focused().type("Child{enter}");
     cy.get("@item").contains("Child").click();
-    cy.focused().should("have.attr", "aria-level", "1");
+    cy.focused().should("have.attr", "aria-level", "2");
   });
 
   it("Creates Internal Nodes", () => {
@@ -95,14 +95,14 @@ describe("Testing the Gmail Demo", () => {
     cy.focused().type("Root{enter}");
     cy.get("@item").contains("Root").click();
     cy.focused().children().should("have.class", "isInternal");
-    cy.focused().should("have.attr", "aria-level", "0");
+    cy.focused().should("have.attr", "aria-level", "1");
 
     // On a folder that is open
     cy.get("@item").contains("Categories").click(); // opened it
     cy.focused().type("A");
     cy.focused().type("Child{enter}");
     cy.get("@item").contains("Child").click();
-    cy.focused().should("have.attr", "aria-level", "1");
+    cy.focused().should("have.attr", "aria-level", "2");
   });
 
   it("drags and drops in its list", () => {

--- a/packages/react-arborist/src/components/default-container.tsx
+++ b/packages/react-arborist/src/components/default-container.tsx
@@ -18,6 +18,7 @@ export function DefaultContainer() {
   const tree = useTreeApi();
   return (
     <div
+      role="tree"
       style={{
         height: tree.height,
         width: tree.width,

--- a/packages/react-arborist/src/components/row-container.tsx
+++ b/packages/react-arborist/src/components/row-container.tsx
@@ -58,7 +58,7 @@ export const RowContainer = React.memo(function RowContainer<T>({
   );
   const rowAttrs: React.HTMLAttributes<any> = {
     role: "treeitem",
-    "aria-level": node.level,
+    "aria-level": node.level + 1,
     "aria-selected": node.isSelected,
     style: rowStyle,
     tabIndex: -1,


### PR DESCRIPTION
This tree component has accessibility violations caught by Axe, and this PR addresses the violation for aria role and aria-level.

The row component has a role "treeitem", which requires a parent component with role "tree".
Also, aria-levels must be greater than or equal to 1, and since the root node starts at 0, this was causing another accessibility violation

<img width="655" alt="Screenshot 2023-12-04 at 2 47 10 PM" src="https://github.com/brimdata/react-arborist/assets/24374917/e860c3c4-bfe1-49c8-bd4d-f7a367e4b834">

<img width="996" alt="Screenshot 2023-12-04 at 4 34 04 PM" src="https://github.com/brimdata/react-arborist/assets/24374917/0395af20-12b1-4064-8dfb-ec2d761e8cf5">

Fixes #197