### PR TITLE
fix: showcase indexpage crash in next@14

### DIFF
--- a/packages/showcase/pages/index.tsx
+++ b/packages/showcase/pages/index.tsx
@@ -26,7 +26,7 @@ const Home: NextPage = () => {
         </p>
 
         <div className={styles.demos}>
-          <Link href="/gmail">
+          <Link href="/gmail" legacyBehavior>
             <div className={styles.demoCard}>
               <div className={`${styles.demoCardImage} gmail`}></div>
               <b>Custom Styles</b>
@@ -39,7 +39,7 @@ const Home: NextPage = () => {
             </div>
           </Link>
 
-          <Link href="/cities">
+          <Link href="/cities" legacyBehavior>
             <div className={styles.demoCard}>
               <div className={`${styles.demoCardImage} cities`}></div>
               <b>30,000 Nodes</b>


### PR DESCRIPTION
nextjs@14 change the `next/link` behavior, showcase indexpage will crash in nextjs@14

![image](https://github.com/brimdata/react-arborist/assets/1615364/01de5df6-a201-4c29-88fd-6e14a1bb78ba)

try to use `legacyBehavior` fix this problem