### PR TITLE
Add `aria-expanded` attribute to rows

### DIFF
--- a/modules/e2e/cypress/e2e/gmail-spec.cy.js
+++ b/modules/e2e/cypress/e2e/gmail-spec.cy.js
@@ -61,6 +61,7 @@ describe("Testing the Gmail Demo", () => {
 
     // On a folder that is closed
     cy.get("@item").contains("Categories").click(); // closed it
+    cy.focused().should("have.attr", "aria-expanded", "false");
     cy.focused().type("a");
     cy.focused().type("Root{enter}");
     cy.get("@item").contains("Root").click();
@@ -68,6 +69,7 @@ describe("Testing the Gmail Demo", () => {
 
     // On a folder that is open
     cy.get("@item").contains("Categories").click(); // opened it
+    cy.focused().should("have.attr", "aria-expanded", "true");
     cy.focused().type("a");
     cy.focused().type("Child{enter}");
     cy.get("@item").contains("Child").click();
@@ -91,6 +93,7 @@ describe("Testing the Gmail Demo", () => {
 
     // On a folder that is closed
     cy.get("@item").contains("Categories").click(); // closed it
+    cy.focused().should("have.attr", "aria-expanded", "false");
     cy.focused().type("A");
     cy.focused().type("Root{enter}");
     cy.get("@item").contains("Root").click();
@@ -99,6 +102,7 @@ describe("Testing the Gmail Demo", () => {
 
     // On a folder that is open
     cy.get("@item").contains("Categories").click(); // opened it
+    cy.focused().should("have.attr", "aria-expanded", "true");
     cy.focused().type("A");
     cy.focused().type("Child{enter}");
     cy.get("@item").contains("Child").click();

--- a/modules/react-arborist/src/components/row-container.tsx
+++ b/modules/react-arborist/src/components/row-container.tsx
@@ -60,6 +60,7 @@ export const RowContainer = React.memo(function RowContainer<T>({
     role: "treeitem",
     "aria-level": node.level + 1,
     "aria-selected": node.isSelected,
+    "aria-expanded": node.isOpen,
     style: rowStyle,
     tabIndex: -1,
     className: tree.props.rowClassName,


### PR DESCRIPTION
On our own project, we saw the need to add the attribute `aria-expanded` to the row elements, since it makes it easier to test with cypress.

This PR adds the attribute `aria-expanded` to the row container with the value `node.isOpen`.

Also updated the tests to verify the change.