### PR TITLE
Add options argument to selectMulti for consistency with select

### DIFF
--- a/modules/react-arborist/src/interfaces/tree-api.ts
+++ b/modules/react-arborist/src/interfaces/tree-api.ts
@@ -344,15 +344,18 @@ export class TreeApi<T> {
     this.dispatch(selection.remove(id));
   }
 
-  selectMulti(identity: Identity) {
+  selectMulti(identity: Identity, opts: { align?: Align; focus?: boolean } = {}) {
     const node = this.get(identifyNull(identity));
     if (!node) return;
-    this.dispatch(focus(node.id));
+    const changeFocus = opts.focus !== false;
+    if (changeFocus) this.dispatch(focus(node.id));
     this.dispatch(selection.add(node.id));
     this.dispatch(selection.anchor(node.id));
     this.dispatch(selection.mostRecent(node.id));
-    this.scrollTo(node);
-    if (this.focusedNode) safeRun(this.props.onFocus, this.focusedNode);
+    this.scrollTo(node, opts.align);
+    if (this.focusedNode && changeFocus) {
+      safeRun(this.props.onFocus, this.focusedNode);
+    }
     safeRun(this.props.onSelect, this.selectedNodes);
   }
 


### PR DESCRIPTION
select(...) supports optional flag to disable focus change but selectMulti(...) doesn't. This change makes the two methods consistent.
It shouldn't break existing code.
I copy-pasted the align option without understanding it.

For reference: [original select](https://github.com/brimdata/react-arborist/compare/main...paulftw:react-arborist:patch-1#diff-7799c27c415642a382c8038fc8c138a83555de2102badd6aa6a3923a7b0117d4R326)