### PR TITLE
build: Upgrade TypeScript, fix 5.6 error

### DIFF
--- a/modules/react-arborist/package.json
+++ b/modules/react-arborist/package.json
@@ -57,6 +57,6 @@
     "npm-run-all": "^4.1.5",
     "rimraf": "^5.0.5",
     "ts-jest": "^29.1.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.6.0"
   }
 }

--- a/modules/react-arborist/src/interfaces/tree-api.ts
+++ b/modules/react-arborist/src/interfaces/tree-api.ts
@@ -593,12 +593,12 @@ export class TreeApi<T> {
 
   isEditable(data: T) {
     const check = this.props.disableEdit || (() => false);
-    return !utils.access(data, check) ?? true;
+    return !utils.access(data, check);
   }
 
   isDraggable(data: T) {
     const check = this.props.disableDrag || (() => false);
-    return !utils.access(data, check) ?? true;
+    return !utils.access(data, check);
   }
 
   isDragging(node: string | IdObj | null) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7947,7 +7947,7 @@ __metadata:
     redux: "npm:^5.0.0"
     rimraf: "npm:^5.0.5"
     ts-jest: "npm:^29.1.1"
-    typescript: "npm:^5.3.3"
+    typescript: "npm:^5.6.0"
     use-sync-external-store: "npm:^1.2.0"
   peerDependencies:
     react: ">= 16.14"
@@ -9535,6 +9535,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:^5.6.0":
+  version: 5.6.2
+  resolution: "typescript@npm:5.6.2"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: f95365d4898f357823e93d334ecda9fcade54f009b397c7d05b7621cd9e865981033cf89ccde0f3e3a7b73b1fdbae18e92bc77db237b43e912f053fef0f9a53b
+  languageName: node
+  linkType: hard
+
 "typescript@patch:typescript@npm%3A^5.3.3#optional!builtin<compat/typescript>":
   version: 5.3.3
   resolution: "typescript@patch:typescript@npm%3A5.3.3#optional!builtin<compat/typescript>::version=5.3.3&hash=e012d7"
@@ -9542,6 +9552,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: c93786fcc9a70718ba1e3819bab56064ead5817004d1b8186f8ca66165f3a2d0100fee91fa64c840dcd45f994ca5d615d8e1f566d39a7470fc1e014dbb4cf15d
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A^5.6.0#optional!builtin<compat/typescript>":
+  version: 5.6.2
+  resolution: "typescript@patch:typescript@npm%3A5.6.2#optional!builtin<compat/typescript>::version=5.6.2&hash=e012d7"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 060a7349adf698477b411be4ace470aee6c2c1bd99917fdf5d33697c17ec55c64fe724eb10399387530b50e9913b41528dd8bfcca0a5fc8f8bac63fbb4580a2e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Fixes #271 

The behavior of 

```ts
return !utils.access(data, check);
```

and

```ts
return !utils.access(data, check) ?? true;
```

Is identical because `false ?? true === false` and `true ?? true === true`.