### PR TITLE
Adding minimal required readme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ const data = [
 Use all the defaults. The _initialData_ prop makes the tree an uncontrolled component. Create, move, rename, and delete will be handled internally.
 
 ```jsx
+import { Tree } from 'react-arborist';
+
 function App() {
   return <Tree initialData={data} />;
 }


### PR DESCRIPTION
The readme, very strangely(!) does not include how to load react-arborist. VSCode intellisense is not able to locate where to get `<Tree>` from, at least when I tried it after a fresh install.

