### PR TITLE
Move drop logic from drag end to drop

### DIFF
--- a/modules/react-arborist/src/dnd/drag-hook.ts
+++ b/modules/react-arborist/src/dnd/drag-hook.ts
@@ -6,8 +6,6 @@ import { NodeApi } from "../interfaces/node-api";
 import { DragItem } from "../types/dnd";
 import { DropResult } from "./drop-hook";
 import { actions as dnd } from "../state/dnd-slice";
-import { safeRun } from "../utils";
-import { ROOT_ID } from "../data/create-root";
 
 export function useDragHook<T>(node: NodeApi<T>): ConnectDragSource {
   const tree = useTreeApi();
@@ -24,23 +22,10 @@ export function useDragHook<T>(node: NodeApi<T>): ConnectDragSource {
       },
       end: () => {
         tree.hideCursor();
-        let { parentId, index, dragIds } = tree.state.dnd;
-        // If they held down meta, we need to create a copy
-        // if (drop.dropEffect === "copy")
-        if (tree.canDrop()) {
-          safeRun(tree.props.onMove, {
-            dragIds,
-            parentId: parentId === ROOT_ID ? null : parentId,
-            index: index === null ? 0 : index, // When it's null it was dropped over a folder
-            dragNodes: tree.dragNodes,
-            parentNode: tree.get(parentId),
-          });
-          tree.open(parentId);
-        }
         tree.dispatch(dnd.dragEnd());
       },
     }),
-    [ids, node]
+    [ids, node],
   );
 
   useEffect(() => {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,13 @@
   ],
   "scripts": {
     "build": "yarn workspaces foreach --all run build",
+    "build-lib": "yarn workspace react-arborist build",
     "test": "yarn workspaces foreach --all run test",
+    "watch": "yarn workspace react-arborist watch",
     "bump": "yarn workspace react-arborist version",
+    "clean": "yarn workspace react-arborist clean",
+    "showcase": "yarn workspace showcase start",
+    "start": "run-s clean build-lib && run-p watch showcase",
     "publish": "sh bin/publish"
   },
   "private": true,


### PR DESCRIPTION
Fixes #260

This let's us utilize the "escape" key to cancel a drag. It also cancels a drag if you drop it outside of the tree. Here's a video showing this at work.


https://github.com/user-attachments/assets/d3005366-e388-48ae-acb2-7c3103251bb3

