### PR TITLE
React 19 support: Bump react-window to 1.8.11

### DIFF
--- a/modules/react-arborist/package.json
+++ b/modules/react-arborist/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "react-dnd": "^14.0.3",
     "react-dnd-html5-backend": "^14.0.3",
-    "react-window": "^1.8.10",
+    "react-window": "^1.8.11",
     "redux": "^5.0.0",
     "use-sync-external-store": "^1.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7943,7 +7943,7 @@ __metadata:
     npm-run-all: "npm:^4.1.5"
     react-dnd: "npm:^14.0.3"
     react-dnd-html5-backend: "npm:^14.0.3"
-    react-window: "npm:^1.8.10"
+    react-window: "npm:^1.8.11"
     redux: "npm:^5.0.0"
     rimraf: "npm:^5.0.5"
     ts-jest: "npm:^29.1.1"
@@ -8024,16 +8024,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-window@npm:^1.8.10":
-  version: 1.8.10
-  resolution: "react-window@npm:1.8.10"
+"react-window@npm:^1.8.11":
+  version: 1.8.11
+  resolution: "react-window@npm:1.8.11"
   dependencies:
     "@babel/runtime": "npm:^7.0.0"
     memoize-one: "npm:>=3.1.1 <6"
   peerDependencies:
-    react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
-  checksum: 6f4a713a2012d605370ef4c7026a45ddd6801e428faa4cad558b12b05ba54c00de72de9a360db109db9666f972a3d955b63af9e5a4cd5fbc52411a382273107b
+    react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: bdbac2b664c5a799443b97a32b2f60a00cc13cc14ca8a8b1e81e2dc7dd00d8d54f05743113972fe1a641b57ada5d874b59c3cbe7e8a07a88c6713a0fb65d60f6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
I noticed that when installing react-arborist in a react v19 project, pnpm complains that `react-window` does not support React 19. However, this was simply because the package.json of `react-window` did not have React v19 listed. They recently listed it and released a new version: https://github.com/bvaughn/react-window/pull/798. No changes were made from 1.8.10 to 1.8.11