### PR TITLE
Feat: Add support for windows CTRL keybinds

### DIFF
--- a/modules/react-arborist/src/components/default-container.tsx
+++ b/modules/react-arborist/src/components/default-container.tsx
@@ -77,7 +77,7 @@ export function DefaultContainer() {
         if (e.key === "ArrowDown") {
           e.preventDefault();
           const next = tree.nextNode;
-          if (e.metaKey) {
+          if (e.metaKey || e.ctrlKey) {
             tree.select(tree.focusedNode);
             tree.activate(tree.focusedNode);
             return;
@@ -133,16 +133,16 @@ export function DefaultContainer() {
           }
           return;
         }
-        if (e.key === "a" && e.metaKey && !tree.props.disableMultiSelection) {
+        if (e.key === "a" && (e.metaKey || e.ctrlKey) && !tree.props.disableMultiSelection) {
           e.preventDefault();
           tree.selectAll();
           return;
         }
-        if (e.key === "a" && !e.metaKey && tree.props.onCreate) {
+        if (e.key === "a" && !(e.metaKey || e.ctrlKey) && tree.props.onCreate) {
           tree.createLeaf();
           return;
         }
-        if (e.key === "A" && !e.metaKey) {
+        if (e.key === "A" && !(e.metaKey || e.ctrlKey)) {
           if (!tree.props.onCreate) return;
           tree.createInternal();
           return;

--- a/modules/react-arborist/src/interfaces/node-api.ts
+++ b/modules/react-arborist/src/interfaces/node-api.ts
@@ -197,7 +197,7 @@ export class NodeApi<T = any> {
   }
 
   handleClick = (e: React.MouseEvent) => {
-    if (e.metaKey && !this.tree.props.disableMultiSelection) {
+    if ((e.metaKey || e.ctrlKey) && !this.tree.props.disableMultiSelection) {
       this.isSelected ? this.deselect() : this.selectMulti();
     } else if (e.shiftKey && !this.tree.props.disableMultiSelection) {
       this.selectContiguous();


### PR DESCRIPTION
solves https://github.com/brimdata/react-arborist/issues/303

 **TLDR of the Issue:** Multi-select on Windows needs Ctrl+Click, not Cmd+Click (Meta key).

- [x] Build + Test passing! https://github.com/CodyAdam/react-arborist/actions/runs/14359795681
- [x] Deployed demo available at https://react-arborist-showcase.vercel.app/ 