### PR TITLE
feat: add getTreeLinePrefix utility for tree connector line

### DIFF
--- a/modules/react-arborist/src/index.ts
+++ b/modules/react-arborist/src/index.ts
@@ -7,3 +7,5 @@ export * from "./interfaces/node-api";
 export * from "./interfaces/tree-api";
 export * from "./data/simple-tree";
 export * from "./hooks/use-simple-tree";
+export { getTreeLinePrefix } from "./utils";
+export type { TreeLineChars } from "./utils";

--- a/modules/react-arborist/src/utils.ts
+++ b/modules/react-arborist/src/utils.ts
@@ -173,6 +173,87 @@ export function getInsertIndex(tree: TreeApi<any>) {
   return 0;
 }
 
+export type TreeLineChars = {
+  last: string;
+  middle: string;
+  pipe: string;
+  blank: string;
+};
+
+const defaultTreeLineChars: TreeLineChars = {
+  last: "└ ",
+  middle: "├ ",
+  pipe: "│ ",
+  blank: "\u3000 ",
+};
+
+/**
+ * Generate a tree-line prefix string for a node.
+ *
+ * Returns characters like `├ `, `└ `, `│` that visually connect
+ * parent and child nodes, similar to the Unix `tree` command.
+ *
+ * **Styling note:** The prefix uses Box Drawing characters (`│`, `├`, `└`)
+ * which require a monospace font for correct alignment. Wrap the prefix
+ * in a `<span>` with `fontFamily: "monospace"` and use a consistent
+ * `fontSize` (e.g. 14–16px). Inherited `line-height` or `font-size`
+ * from parent elements can cause misalignment.
+ *
+ * @example Basic usage
+ * ```tsx
+ * function MyNode({ node, style }: NodeRendererProps<MyData>) {
+ *   return (
+ *     <div style={style}>
+ *       <span style={{ fontFamily: "monospace", fontSize: 14 }}>
+ *         {getTreeLinePrefix(node)}
+ *       </span>
+ *       {node.data.name}
+ *     </div>
+ *   );
+ * }
+ * ```
+ *
+ * @example With folder/file icons
+ * ```tsx
+ * function MyNode({ node, style }: NodeRendererProps<MyData>) {
+ *   const icon = node.isLeaf ? "📄" : node.isOpen ? "📂" : "📁";
+ *   return (
+ *     <div style={style}>
+ *       <span style={{ fontFamily: "monospace", fontSize: 16 }}>
+ *         {getTreeLinePrefix(node)}
+ *       </span>
+ *       {icon} {node.data.name}
+ *     </div>
+ *   );
+ * }
+ * ```
+ *
+ * @example Custom characters
+ * ```tsx
+ * // ASCII-only style
+ * getTreeLinePrefix(node, { last: "`- ", middle: "|- ", pipe: "|", blank: "  " })
+ * ```
+ */
+export function getTreeLinePrefix(
+  node: NodeApi<any>,
+  chars: Partial<TreeLineChars> = {}
+): string {
+  const c = { ...defaultTreeLineChars, ...chars };
+  if (node.level === 0) return "";
+
+  const isLast = node.nextSibling === null;
+  let prefix = isLast ? c.last : c.middle;
+
+  let ancestor = node.parent;
+  while (ancestor && ancestor.level > 0) {
+    const isAncestorLast = ancestor.nextSibling === null;
+    prefix = (isAncestorLast ? c.blank : c.pipe) + prefix;
+    ancestor = ancestor.parent;
+  }
+
+  return prefix;
+}
+
 export function getInsertParentId(tree: TreeApi<any>) {
   const focus = tree.focusedNode;
   if (!focus) return null;


### PR DESCRIPTION
  Add a `getTreeLinePrefix()` utility function that generates tree connector line prefixes (`├`, `└`, `│`) for nodes, similar to the Unix `tree` command output.

  Currently, react-arborist does not provide a built-in way to render tree connector lines. Users have to implement the parent-traversal logic themselves in custom node renderers. This utility solves that.

  ## Features

  - Generates correct connector lines by traversing ancestor nodes
  - Customizable characters via `TreeLineChars` option
  - Works with any tree depth
  - Exported from package root for easy access

  ## Usage

  ```tsx
  import { getTreeLinePrefix } from "react-arborist";

  function MyNode({ node, style }: NodeRendererProps<MyData>) {
    const icon = node.isLeaf ? "📄" : node.isOpen ? "📂" : "📁";
    return (
      <div style={style}>
        <span style={{ fontFamily: "monospace", fontSize: 16 }}>
          {getTreeLinePrefix(node)}
        </span>
        {icon} {node.data.name}
      </div>
    );
  }
  

  Result

  📂 src
  ├ 📂 components
  │ ├ 📄 Button.tsx
  │ ├ 📄 Input.tsx
  │ └ 📂 layout
  │   ├ 📄 Header.tsx
  │   ├ 📄 Footer.tsx
  │   └ 📄 Sidebar.tsx
  ├ 📂 pages
  │ ├ 📄 Home.tsx
  │ └ 📄 About.tsx
  ├ 📄 App.tsx
  └ 📄 main.tsx
  📂 public
  ├ 📄 favicon.ico
  └ 📄 index.html
  📄 package.json
  📄 README.md

  Styling Note

  The prefix uses Box Drawing characters which require a monospace font for correct alignment. Wrap the prefix in a <span> with fontFamily: "monospace" and use a consistent fontSize (e.g. 14–16px). Inherited line-height or font-size from parent elements
  can cause misalignment.

  Custom Characters

  // ASCII-only style
  getTreeLinePrefix(node, { last: "`- ", middle: "|- ", pipe: "| ", blank: "  " })