### PR TITLE
Add dndBackend prop to Tree (rebased from #316)

### DIFF
--- a/modules/react-arborist/src/components/provider.tsx
+++ b/modules/react-arborist/src/components/provider.tsx
@@ -87,7 +87,7 @@ export function TreeProvider<T>({
               {...(treeProps.dndManager
                 ? { manager: treeProps.dndManager }
                 : {
-                    backend: HTML5Backend,
+                    backend: treeProps.dndBackend || HTML5Backend,
                     options: {
                       rootElement: api.props.dndRootElement || undefined,
                     },

--- a/modules/react-arborist/src/types/tree-props.ts
+++ b/modules/react-arborist/src/types/tree-props.ts
@@ -5,7 +5,7 @@ import { ElementType, MouseEventHandler } from "react";
 import { ListOnScrollProps } from "react-window";
 import { NodeApi } from "../interfaces/node-api";
 import { OpenMap } from "../state/open-slice";
-import { useDragDropManager } from "react-dnd";
+import { useDragDropManager, DndProviderProps } from "react-dnd";
 
 export interface TreeProps<T> {
   /* Data Options */
@@ -76,5 +76,9 @@ export interface TreeProps<T> {
   dndRootElement?: globalThis.Node | null;
   onClick?: MouseEventHandler;
   onContextMenu?: MouseEventHandler;
+  dndBackend?: Extract<
+    DndProviderProps<unknown, unknown>,
+    { backend: unknown }
+  >["backend"];
   dndManager?: ReturnType<typeof useDragDropManager>;
 }


### PR DESCRIPTION
Rebased version of #316 by @ofk. Combined cleanly with the provider refactor from #237 (`dndManager`-or-`backend`-not-both) so that custom `dndBackend` props flow into the same conditional.

Reopens #316's change against current main after #237 landed.

Closes #316.

Co-authored-by: ofk <ofkjpn+github@gmail.com>