### PR TITLE
Switch npm publishing to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,14 +7,15 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "20.x"
           registry-url: "https://registry.npmjs.org"
+      - run: npm install -g npm@latest
       - run: yarn
       - run: sh bin/publish --tag latest
-        env:
-          YARN_NPM_REGISTRY_SERVER: "https://registry.npmjs.org"
-          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}

--- a/bin/publish
+++ b/bin/publish
@@ -1,5 +1,6 @@
 #!/bin/sh
+set -e
 
-yarn build
+yarn build-lib
 cp README.md modules/react-arborist/README.md
-yarn workspace react-arborist npm publish $@
+(cd modules/react-arborist && npm publish "$@")

--- a/modules/react-arborist/package.json
+++ b/modules/react-arborist/package.json
@@ -22,10 +22,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/brimdata/react-arborist.git"
+    "url": "https://github.com/jameskerr/react-arborist.git"
   },
   "homepage": "https://react-arborist.netlify.app",
-  "bugs": "https://github.com/brimdata/react-arborist/issues",
+  "bugs": "https://github.com/jameskerr/react-arborist/issues",
   "keywords": [
     "react",
     "arborist",


### PR DESCRIPTION
Replaces the long-lived NPM_ACCESS_TOKEN secret with GitHub Actions OIDC. Any maintainer with write access to this repo can cut a release; CI authenticates to npm directly via a short-lived OIDC token. Publishes also get provenance attestations automatically.

## Changes

- \`publish.yml\`: add \`id-token: write\` permission, drop \`NPM_ACCESS_TOKEN\` env, upgrade \`checkout\`/\`setup-node\` to v4, install latest npm for OIDC support.
- \`bin/publish\`: switch from \`yarn workspace ... npm publish\` to \`npm publish\` (yarn 4 does not participate in GitHub OIDC token exchange). Use \`yarn build-lib\` so we only build the package being published.
- \`modules/react-arborist/package.json\`: fix \`repository.url\` and \`bugs\` URLs (\`brimdata\` → \`jameskerr\`). npm's trusted-publisher check requires this to match the configured publisher.

## One-time npm configuration (required before first OIDC publish)

On https://www.npmjs.com/package/react-arborist under Settings → Trusted Publishers, add a GitHub Actions publisher:

- Organization/user: \`jameskerr\`
- Repository: \`react-arborist\`
- Workflow filename: \`publish.yml\`
- Environment: (leave blank)

Then delete the stale \`NPM_ACCESS_TOKEN\` repo secret.

## Test plan

- [x] \`npm publish --dry-run\` locally — package contents look correct (3.5.0, 237 files, 63 kB tarball)
- [ ] After merge + Trusted Publisher setup, dispatch the workflow from \`main\` to publish v3.5.0 to npm
- [ ] Verify \`npm view react-arborist\` shows 3.5.0 and a provenance attestation link