### PR TITLE
Add disableSelect prop (rebased from #169)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Testing Locally
 
 1. Clone the repo
-2. From the root, run yarn && yarn start
-3. Visit localhost:3000
+2. From the root, run `yarn && yarn start`
+3. Visit <localhost:3000>
 
 # Running Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 1. Clone the repo
 2. From the root, run `yarn && yarn start`
-3. Visit <localhost:3000>
+3. Visit <http://localhost:3000>
 
 # Running Tests
 

--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ interface TreeProps<T> {
   openByDefault?: boolean;
   selectionFollowsFocus?: boolean;
   disableMultiSelection?: boolean;
+  disableSelect?: string | boolean | BoolFunc<T>;
   disableEdit?: string | boolean | BoolFunc<T>;
   disableDrag?: string | boolean | BoolFunc<T>;
   disableDrop?:

--- a/modules/e2e/cypress/e2e/gmail-spec.cy.js
+++ b/modules/e2e/cypress/e2e/gmail-spec.cy.js
@@ -149,6 +149,11 @@ describe("Testing the Gmail Demo", () => {
     cy.focused().should("have.attr", "aria-selected", "true");
     cy.get("@item").contains("Categories").click();
     cy.focused().should("have.attr", "aria-selected", "false");
+    // Existing selection on Inbox is preserved when clicking an unselectable node
+    cy.get("@item")
+      .contains("Inbox")
+      .parents("[role=treeitem]")
+      .should("have.attr", "aria-selected", "true");
   });
 
   it("select all does not select categories or spam", () => {

--- a/modules/e2e/cypress/e2e/gmail-spec.cy.js
+++ b/modules/e2e/cypress/e2e/gmail-spec.cy.js
@@ -143,6 +143,23 @@ describe("Testing the Gmail Demo", () => {
     cy.get("@item").contains("Categories").click(); // collapses
     cy.get("@item").should("have.length", 1);
   });
+
+  it("can select inbox but not categories", () => {
+    cy.get("@item").contains("Inbox").click();
+    cy.focused().should("have.attr", "aria-selected", "true");
+    cy.get("@item").contains("Categories").click();
+    cy.focused().should("have.attr", "aria-selected", "false");
+  });
+
+  it("select all does not select categories or spam", () => {
+    cy.get("@item").contains("Inbox").click();
+    cy.focused().type("{meta}a");
+    cy.get("[aria-selected='true']")
+      .should("not.contain.text", "Categories")
+      .should("not.contain.text", "Spam")
+      .should("contain.text", "Inbox")
+      .should("have.length", TOTAL_ITEMS - 2);
+  });
 });
 
 function dragAndDrop(src, dst) {

--- a/modules/react-arborist/src/interfaces/node-api.ts
+++ b/modules/react-arborist/src/interfaces/node-api.ts
@@ -59,6 +59,10 @@ export class NodeApi<T = any> {
     return this.tree.isEditable(this.data);
   }
 
+  get isSelectable() {
+    return this.tree.isSelectable(this.data);
+  }
+
   get isEditing() {
     return this.tree.editingId === this.id;
   }

--- a/modules/react-arborist/src/interfaces/tree-api.ts
+++ b/modules/react-arborist/src/interfaces/tree-api.ts
@@ -1,5 +1,5 @@
 import { EditResult } from "../types/handlers";
-import { Identity, IdObj } from "../types/utils";
+import { BoolFunc, Identity, IdObj } from "../types/utils";
 import { TreeProps } from "../types/tree-props";
 import { MutableRefObject } from "react";
 import { Align, FixedSizeList, ListOnItemsRenderedProps } from "react-window";
@@ -328,9 +328,13 @@ export class TreeApi<T> {
     const changeFocus = opts.focus !== false;
     const id = identify(node);
     if (changeFocus) this.dispatch(focus(id));
-    this.dispatch(selection.only(id));
-    this.dispatch(selection.anchor(id));
-    this.dispatch(selection.mostRecent(id));
+    if (this.get(id)?.isSelectable) {
+      this.setSelection({
+        ids: [id],
+        anchor: id,
+        mostRecent: id,
+      });
+    }
     this.scrollTo(id, opts.align);
     if (this.focusedNode && changeFocus) {
       safeRun(this.props.onFocus, this.focusedNode);
@@ -350,9 +354,11 @@ export class TreeApi<T> {
     if (!node) return;
     const changeFocus = opts.focus !== false;
     if (changeFocus) this.dispatch(focus(node.id));
-    this.dispatch(selection.add(node.id));
-    this.dispatch(selection.anchor(node.id));
-    this.dispatch(selection.mostRecent(node.id));
+    if (node.isSelectable) {
+      this.dispatch(selection.add(node.id));
+      this.dispatch(selection.anchor(node.id));
+      this.dispatch(selection.mostRecent(node.id));
+    }
     this.scrollTo(node, opts.align);
     if (this.focusedNode && changeFocus) {
       safeRun(this.props.onFocus, this.focusedNode);
@@ -363,11 +369,13 @@ export class TreeApi<T> {
   selectContiguous(identity: Identity) {
     if (!identity) return;
     const id = identify(identity);
-    const { anchor, mostRecent } = this.state.nodes.selection;
     this.dispatch(focus(id));
-    this.dispatch(selection.remove(this.nodesBetween(anchor, mostRecent)));
-    this.dispatch(selection.add(this.nodesBetween(anchor, identifyNull(id))));
-    this.dispatch(selection.mostRecent(id));
+    if (this.get(id)?.isSelectable) {
+      const {anchor, mostRecent} = this.state.nodes.selection;
+      this.dispatch(selection.remove(this.nodesBetween(anchor, mostRecent)));
+      this.dispatch(selection.add(this.nodesBetween(anchor, identifyNull(id)).filter(n => n.isSelectable)));
+      this.dispatch(selection.mostRecent(id));
+    }
     this.scrollTo(id);
     if (this.focusedNode) safeRun(this.props.onFocus, this.focusedNode);
     safeRun(this.props.onSelect, this.selectedNodes);
@@ -379,8 +387,12 @@ export class TreeApi<T> {
   }
 
   selectAll() {
+    const selectableIds = Object.keys(this.idToIndex)
+      .map(id => this.get(id)!)
+      .filter(n => !!n && n.isSelectable)
+      .map(node => node.id);
     this.setSelection({
-      ids: Object.keys(this.idToIndex),
+      ids: selectableIds,
       anchor: this.firstNode,
       mostRecent: this.lastNode,
     });
@@ -596,13 +608,22 @@ export class TreeApi<T> {
   }
 
   isEditable(data: T) {
-    const check = this.props.disableEdit || (() => false);
-    return !utils.access(data, check);
+    return this.isActionPossible(data, this.props.disableEdit);
   }
 
   isDraggable(data: T) {
-    const check = this.props.disableDrag || (() => false);
-    return !utils.access(data, check);
+    return this.isActionPossible(data, this.props.disableDrag);
+  }
+
+  isSelectable(data: T) {
+    return this.isActionPossible(data, this.props.disableSelect);
+  }
+
+  private isActionPossible(
+    data: T,
+    disabler: string | boolean | BoolFunc<T> | undefined = () => false,
+  ) {
+    return !utils.access(data, disabler);
   }
 
   isDragging(node: string | IdObj | null) {

--- a/modules/react-arborist/src/interfaces/tree-api.ts
+++ b/modules/react-arborist/src/interfaces/tree-api.ts
@@ -371,8 +371,10 @@ export class TreeApi<T> {
     const id = identify(identity);
     this.dispatch(focus(id));
     if (this.get(id)?.isSelectable) {
-      const {anchor, mostRecent} = this.state.nodes.selection;
-      const selectableNodes = this.filterSelectableNodes(this.nodesBetween(anchor, identifyNull(id)))
+      const { anchor, mostRecent } = this.state.nodes.selection;
+      const selectableNodes = this.filterSelectableNodes(
+        this.nodesBetween(anchor, identifyNull(id)),
+      );
       this.dispatch(selection.remove(this.nodesBetween(anchor, mostRecent)));
       this.dispatch(selection.add(selectableNodes));
       this.dispatch(selection.mostRecent(id));
@@ -401,8 +403,8 @@ export class TreeApi<T> {
 
   private filterSelectableNodes(nodes: (IdObj | string)[]) {
     return nodes
-      .map(n => this.get(identify(n)))
-      .filter(n => !!n && n.isSelectable) as NodeApi<T>[];
+      .map((n) => this.get(identify(n)))
+      .filter((n): n is NodeApi<T> => !!n && n.isSelectable);
   }
 
   setSelection(args: {

--- a/modules/react-arborist/src/interfaces/tree-api.ts
+++ b/modules/react-arborist/src/interfaces/tree-api.ts
@@ -621,7 +621,7 @@ export class TreeApi<T> {
 
   private isActionPossible(
     data: T,
-    disabler: string | boolean | BoolFunc<T> | undefined = () => false,
+    disabler: string | boolean | BoolFunc<T> = () => false,
   ) {
     return !utils.access(data, disabler);
   }

--- a/modules/react-arborist/src/interfaces/tree-api.ts
+++ b/modules/react-arborist/src/interfaces/tree-api.ts
@@ -372,8 +372,9 @@ export class TreeApi<T> {
     this.dispatch(focus(id));
     if (this.get(id)?.isSelectable) {
       const {anchor, mostRecent} = this.state.nodes.selection;
+      const selectableNodes = this.filterSelectableNodes(this.nodesBetween(anchor, identifyNull(id)))
       this.dispatch(selection.remove(this.nodesBetween(anchor, mostRecent)));
-      this.dispatch(selection.add(this.nodesBetween(anchor, identifyNull(id)).filter(n => n.isSelectable)));
+      this.dispatch(selection.add(selectableNodes));
       this.dispatch(selection.mostRecent(id));
     }
     this.scrollTo(id);
@@ -387,18 +388,21 @@ export class TreeApi<T> {
   }
 
   selectAll() {
-    const selectableIds = Object.keys(this.idToIndex)
-      .map(id => this.get(id)!)
-      .filter(n => !!n && n.isSelectable)
-      .map(node => node.id);
+    const allSelectableNodes = this.filterSelectableNodes(Object.keys(this.idToIndex));
     this.setSelection({
-      ids: selectableIds,
+      ids: allSelectableNodes,
       anchor: this.firstNode,
       mostRecent: this.lastNode,
     });
     this.dispatch(focus(this.lastNode?.id));
     if (this.focusedNode) safeRun(this.props.onFocus, this.focusedNode);
     safeRun(this.props.onSelect, this.selectedNodes);
+  }
+
+  private filterSelectableNodes(nodes: (IdObj | string)[]) {
+    return nodes
+      .map(n => this.get(identify(n)))
+      .filter(n => !!n && n.isSelectable) as NodeApi<T>[];
   }
 
   setSelection(args: {

--- a/modules/react-arborist/src/interfaces/tree-api.ts
+++ b/modules/react-arborist/src/interfaces/tree-api.ts
@@ -339,7 +339,6 @@ export class TreeApi<T> {
     if (this.focusedNode && changeFocus) {
       safeRun(this.props.onFocus, this.focusedNode);
     }
-    safeRun(this.props.onSelect, this.selectedNodes);
   }
 
   deselect(node: Identity) {
@@ -390,11 +389,13 @@ export class TreeApi<T> {
   }
 
   selectAll() {
-    const allSelectableNodes = this.filterSelectableNodes(Object.keys(this.idToIndex));
+    const allSelectableNodes = this.filterSelectableNodes(
+      Object.keys(this.idToIndex),
+    );
     this.setSelection({
       ids: allSelectableNodes,
-      anchor: this.firstNode,
-      mostRecent: this.lastNode,
+      anchor: allSelectableNodes[0] ?? null,
+      mostRecent: allSelectableNodes[allSelectableNodes.length - 1] ?? null,
     });
     this.dispatch(focus(this.lastNode?.id));
     if (this.focusedNode) safeRun(this.props.onFocus, this.focusedNode);

--- a/modules/react-arborist/src/interfaces/tree-api.ts
+++ b/modules/react-arborist/src/interfaces/tree-api.ts
@@ -169,7 +169,7 @@ export class TreeApi<T> {
     return this.visibleNodes.slice(start, end + 1);
   }
 
-  indexOf(id: string | null | IdObj) {
+  indexOf(id: Identity) {
     const key = utils.identifyNull(id);
     if (!key) return null;
     return this.idToIndex[key];
@@ -219,7 +219,7 @@ export class TreeApi<T> {
     }
   }
 
-  async delete(node: string | IdObj | null | string[] | IdObj[]) {
+  async delete(node: Identity | string[] | IdObj[]) {
     if (!node) return;
     const idents = Array.isArray(node) ? node : [node];
     const ids = idents.map(identify);
@@ -256,7 +256,7 @@ export class TreeApi<T> {
     setTimeout(() => this.onFocus()); // Return focus to element;
   }
 
-  activate(id: string | IdObj | null) {
+  activate(id: Identity) {
     const node = this.get(identifyNull(id));
     if (!node) return;
     safeRun(this.props.onActivate, node);
@@ -407,8 +407,8 @@ export class TreeApi<T> {
 
   setSelection(args: {
     ids: (IdObj | string)[] | null;
-    anchor: IdObj | string | null;
-    mostRecent: IdObj | string | null;
+    anchor: Identity;
+    mostRecent: Identity;
   }) {
     const ids = new Set(args.ids?.map(identify));
     const anchor = identifyNull(args.anchor);
@@ -630,7 +630,7 @@ export class TreeApi<T> {
     return !utils.access(data, disabler);
   }
 
-  isDragging(node: string | IdObj | null) {
+  isDragging(node: Identity) {
     const id = identifyNull(node);
     if (!id) return false;
     return this.state.nodes.drag.id === id;
@@ -644,7 +644,7 @@ export class TreeApi<T> {
     return this.matchFn(node);
   }
 
-  willReceiveDrop(node: string | IdObj | null) {
+  willReceiveDrop(node: Identity) {
     const id = identifyNull(node);
     if (!id) return false;
     const { destinationParentId, destinationIndex } = this.state.nodes.drag;

--- a/modules/react-arborist/src/types/tree-props.ts
+++ b/modules/react-arborist/src/types/tree-props.ts
@@ -41,6 +41,7 @@ export interface TreeProps<T> {
   openByDefault?: boolean;
   selectionFollowsFocus?: boolean;
   disableMultiSelection?: boolean;
+  disableSelect?: string | boolean | BoolFunc<T>;
   disableEdit?: string | boolean | BoolFunc<T>;
   disableDrag?: string | boolean | BoolFunc<T>;
   disableDrop?:

--- a/modules/showcase/pages/gmail.tsx
+++ b/modules/showcase/pages/gmail.tsx
@@ -79,18 +79,18 @@ export default function GmailSidebar() {
           <p>The tree is fully functional. Try the following:</p>
           <ul>
             <li>Drag the items around</li>
-            <li>Try to drag Inbox into 'Categories' (not allowed)</li>
+            <li>Try to drag Inbox into {"'"}Categories{"'"} (not allowed)</li>
             <li>Move focus with the arrow keys</li>
             <li>Toggle folders (press spacebar)</li>
             <li>
-              Rename (press enter, only allowed on items in 'Categories'
+              Rename (press enter, only allowed on items in {"'"}Categories{"'"}
               )
             </li>
             <li>Create a new item (press A)</li>
             <li>Create a new folder (press shift+A)</li>
             <li>Delete items (press delete)</li>
             <li>Select multiple items with shift or meta</li>
-            <li>'Categories' and 'Spam' cannot be selected</li>
+            <li>{"'"}Categories{"'"} and {"'"}Spam{"'"} cannot be selected</li>
             <li>
               Filter the tree by typing in this text box:{" "}
               <input

--- a/modules/showcase/pages/gmail.tsx
+++ b/modules/showcase/pages/gmail.tsx
@@ -47,6 +47,7 @@ export default function GmailSidebar() {
                   renderCursor={Cursor}
                   searchTerm={term}
                   paddingBottom={32}
+                  disableSelect={(data) => ["Categories", "Spam"].includes(data.name)}
                   disableEdit={(data) => data.readOnly}
                   disableDrop={({ parentNode, dragNodes }) => {
                     if (
@@ -78,17 +79,18 @@ export default function GmailSidebar() {
           <p>The tree is fully functional. Try the following:</p>
           <ul>
             <li>Drag the items around</li>
-            <li>Try to drag Inbox into Categories (not allowed)</li>
+            <li>Try to drag Inbox into 'Categories' (not allowed)</li>
             <li>Move focus with the arrow keys</li>
             <li>Toggle folders (press spacebar)</li>
             <li>
-              Rename (press enter, only allowed on items in {"'"}Categories{"'"}
+              Rename (press enter, only allowed on items in 'Categories'
               )
             </li>
             <li>Create a new item (press A)</li>
             <li>Create a new folder (press shift+A)</li>
             <li>Delete items (press delete)</li>
             <li>Select multiple items with shift or meta</li>
+            <li>'Categories' and 'Spam' cannot be selected</li>
             <li>
               Filter the tree by typing in this text box:{" "}
               <input


### PR DESCRIPTION
Resurrects @boriskor's #169, rebased onto current main with style cleanup. Closes #56.

## Summary

Adds a `disableSelect` Tree prop in the spirit of `disableEdit` and `disableDrag` — accepts `string | boolean | BoolFunc<T>`. When the predicate returns true for a node, that node can't be selected via click, keyboard, `selectionFollowsFocus`, `selectAll`, or any of the imperative select methods. Focus still moves through the disabled node (so keyboard navigation isn't blocked); only selection is gated.

Closes #56, which @jameskerr opened in 2022 asking for exactly this API.

## What changed vs #169

- Rebased onto current main (resolved conflicts with #266's `selectMulti(opts)` and the `isActionPossible` refactor).
- Style cleanup commit on top: matched repo formatting in `filterSelectableNodes` / `selectContiguous`, replaced an `as NodeApi<T>[]` cast with a type-guarded filter predicate.
- Original commits preserved with @boriskor as author.

## Coverage

- Gates `select`, `selectMulti`, `selectContiguous`, `selectAll`. `selectionFollowsFocus` flows through `select` so it's gated too.
- `setSelection` (imperative escape hatch) is intentionally not gated.
- Adds `node.isSelectable` getter on `NodeApi`.
- Cypress e2e tests against the Gmail showcase (covers click + select-all behaviors).
- Showcase updated to demo with Categories/Spam disabled.
- README documents the new prop.

## Test plan

- [x] CI green (build + existing tests)
- [ ] e2e: clicking Categories doesn't select it; cmd-A skips Categories and Spam
- [ ] Manual: arrow-key navigation still passes through a disabled node when `selectionFollowsFocus` is on, but the node doesn't get selected
- [ ] Manual: existing selection is preserved when clicking a disabled node (not cleared)

🤖 Generated with [Claude Code](https://claude.com/claude-code)