### PR TITLE
Run only react-arborist unit tests in release script

### DIFF
--- a/bin/release.mjs
+++ b/bin/release.mjs
@@ -86,7 +86,7 @@ if (flags.anyBranch) {
 
 if (!flags.skipTests) {
   step("Running tests");
-  run("yarn test");
+  run("yarn workspace react-arborist test");
 }
 
 step("Building library");


### PR DESCRIPTION
## Summary

Root `yarn test` is `workspaces foreach --all run test`, which includes the `e2e` module. `e2e`'s test command boots a static showcase server (`serve ./out`) and runs Cypress against it. Two problems for the release flow:

- It requires a prior `next build` of the showcase, otherwise `serve` hangs silently (`> /dev/null` swallows the error). `yarn release minor` got stuck here.
- E2e tests aren't a release gate anyway — the `Build & Test` PR workflow runs them on every PR.

## Change

Scope the release-time test step to `yarn workspace react-arborist test` so it only runs the library's unit tests.

## Test plan

- [x] `yarn release minor --preview --any-branch` runs jest only and completes
- [ ] Real release on the next version cut