### PR TITLE
Fix release script tag push and publish GitHub release directly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,19 +14,19 @@ To test individual modules, cd into them and run `yarn test`. For example, runni
 
 Releases are driven by `bin/release.mjs`, invoked via `yarn release`. The script bumps the version, runs tests, and pushes a `v*` tag. The tag push triggers `.github/workflows/publish.yml`, which publishes to npm via Trusted Publishing (OIDC) — no token needed.
 
-1. On `main`, with a clean working tree, update `CHANGELOG.md` with a new section for the upcoming version. Commit and push.
+1. On `main`, with a clean working tree, update `CHANGELOG.md` with a new `# Version X.Y.Z` section for the upcoming version. Commit and push.
 2. Run `yarn release <patch|minor|major|X.Y.Z>` from the repo root. The script will:
    - Verify you're on `main`, the working tree is clean, and you're in sync with the remote
-   - Run tests and build
+   - Run unit tests and build
+   - Read the matching `# Version X.Y.Z` section from `CHANGELOG.md` (fails if missing)
    - Bump `modules/react-arborist/package.json`, commit it, and tag `vX.Y.Z`
-   - Push the commit and tag to `origin`
-   - Open a GitHub Release draft in your browser (via `gh`)
-3. Edit the release draft, paste in the changelog entry, and publish.
-4. Watch `gh run watch` — the publish workflow will build and `npm publish` via OIDC. Confirm the new version on https://www.npmjs.com/package/react-arborist.
+   - Push the commit and tag to your tracking remote
+   - Create a GitHub Release for the tag using the changelog section as the body
+3. Watch `gh run watch` — the publish workflow will build and `npm publish` via OIDC. Confirm the new version on https://www.npmjs.com/package/react-arborist.
 
 Flags:
 
-- `--preview` — dry-run; the script still reads git state and builds, but no commit, tag, push, or release draft is created.
+- `--preview` — dry-run; the script still reads git state and builds, but no commit, tag, push, or release is created.
 - `--any-branch` — skip both the `main` branch check and the remote sync check (useful for testing on a branch that isn't pushed).
 - `--no-tests` — skip `yarn test`.
 - `--yes` — skip the interactive confirmation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Flags:
 
 - `--preview` — dry-run; the script still reads git state and builds, but no commit, tag, push, or release is created.
 - `--any-branch` — skip both the `main` branch check and the remote sync check (useful for testing on a branch that isn't pushed).
-- `--no-tests` — skip `yarn test`.
+- `--no-tests` — skip the unit test step (`yarn workspace react-arborist test`).
 - `--yes` — skip the interactive confirmation.
 
 # Publish the Demo Site

--- a/bin/release.mjs
+++ b/bin/release.mjs
@@ -3,11 +3,13 @@ import { execSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 import { createInterface } from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const pkgPath = path.join(rootDir, "modules/react-arborist/package.json");
+const changelogPath = path.join(rootDir, "CHANGELOG.md");
 
 const args = process.argv.slice(2);
 const flags = {
@@ -46,6 +48,14 @@ function bump(current, kind) {
   if (kind === "minor") return `${maj}.${min + 1}.0`;
   if (kind === "major") return `${maj + 1}.0.0`;
   fail(`Invalid version: "${kind}". Use patch, minor, major, or X.Y.Z.`);
+}
+
+function readChangelogSection(version) {
+  const content = readFileSync(changelogPath, "utf8");
+  const escaped = version.replace(/\./g, "\\.");
+  const re = new RegExp(`^# Version ${escaped}\\s*\\n([\\s\\S]*?)(?=^# Version |\\Z)`, "m");
+  const match = content.match(re);
+  return match ? match[1].trim() : null;
 }
 
 if (!versionArg) {
@@ -103,6 +113,12 @@ if (out(`git tag -l ${tag}`)) {
   fail(`Tag ${tag} already exists.`);
 }
 
+const releaseNotes = readChangelogSection(newVersion);
+if (!releaseNotes) {
+  fail(`No "# Version ${newVersion}" section found in CHANGELOG.md. Add one before releasing.`);
+}
+console.log(`\nRelease notes (from CHANGELOG.md):\n${releaseNotes}\n`);
+
 if (!flags.preview && !flags.yes) {
   const rl = createInterface({ input, output });
   const answer = await rl.question(`Continue? (y/N) `);
@@ -125,12 +141,22 @@ step("Committing");
 run(`git commit -am ${tag}`);
 
 step(`Tagging ${tag}`);
-run(`git tag ${tag}`);
+run(`git tag -a ${tag} -m ${tag}`);
 
 step(`Pushing commit + tag to ${remoteName}`);
-run(`git push ${remoteName} ${branch} --follow-tags`);
+run(`git push ${remoteName} ${branch} ${tag}`);
 
-step("Opening GitHub release draft");
-run(`gh release create ${tag} --draft --title ${tag} --notes "" --web`);
+step("Creating GitHub release");
+const remoteUrl = out(`git config --get remote.${remoteName}.url`);
+const repoMatch = remoteUrl.match(/[:/]([^/:]+)\/([^/]+?)(?:\.git)?$/);
+if (!repoMatch) fail(`Could not parse owner/repo from remote URL: ${remoteUrl}`);
+const repo = `${repoMatch[1]}/${repoMatch[2]}`;
+const notesPath = path.join(os.tmpdir(), `release-notes-${tag}.md`);
+if (flags.preview) {
+  console.log(`  [preview] write notes to ${notesPath}`);
+} else {
+  writeFileSync(notesPath, releaseNotes + "\n");
+}
+run(`gh release create ${tag} --repo ${repo} --title ${tag} --notes-file ${notesPath}`);
 
 console.log(`\nReleased ${tag}. Watch the publish workflow with: gh run watch`);


### PR DESCRIPTION
## Summary

Two bugs hit during the v3.6.0 cut, plus an improvement so `yarn release` finishes the release on its own.

### Fix 1: tag never reached upstream

`git tag <tag>` creates a lightweight tag. `git push --follow-tags` only pushes annotated tags, so the v* tag stayed local and the publish workflow didn't fire. Switch to an annotated tag (`git tag -a`) and push it explicitly (`git push <remote> <branch> <tag>`).

### Fix 2: `gh release create --web` is invalid

Only `gh pr create` supports `--web`. The script crashed at the very last step with the tag already pushed. Drop the flag and derive the repo from the tracking remote URL so the release lands on the right repo in a fork-with-upstream setup.

### Improvement: publish the release, don't draft it

`yarn release` now reads the matching `# Version X.Y.Z` section from `CHANGELOG.md` and creates a published GitHub Release with that body. No more manually editing an empty draft and clicking Publish. The script fails fast if the section is missing, before doing any writes.

## Test plan

- [x] `yarn release patch --preview --any-branch --no-tests` shows annotated tag, explicit tag push, and `gh release create` without `--web` or `--draft`
- [x] Changelog parser tested manually for v3.5.0, v3.6.0, and a non-existent version
- [x] Script fails with clear error if `# Version X.Y.Z` is missing from `CHANGELOG.md`
- [ ] Real release on the next version cut