### PR TITLE
Preserve imperative tree.update() props across node toggles

### DIFF
--- a/modules/react-arborist/src/components/provider.tsx
+++ b/modules/react-arborist/src/components/provider.tsx
@@ -57,7 +57,15 @@ export function TreeProvider<T>({
   useMemo(() => {
     updateCount.current += 1;
     api.update(treeProps);
-  }, [...Object.values(treeProps), state.nodes.open]);
+  }, [...Object.values(treeProps)]);
+
+  /* Rebuild visible nodes when open state changes, without clobbering
+     props set imperatively via api.update(). Bumping updateCount keeps
+     DataUpdates consumers (e.g. DefaultContainer) in sync. */
+  useMemo(() => {
+    updateCount.current += 1;
+    api.update(api.props);
+  }, [state.nodes.open]);
 
   /* Expose the tree api */
   useImperativeHandle(imperativeHandle, () => api);


### PR DESCRIPTION
Picks up #229 from @iamyunsin (which targeted the old `packages/` path and went stale), ports the fix to the current `modules/` layout, and credits the original author via `Co-Authored-By`.

## The bug

Closes #228 (partially — see Notes).

`TreeProvider` had a single `useMemo` that re-ran on either `treeProps` changes **or** `state.nodes.open` changes, always calling `api.update(treeProps)`. That meant any prop a consumer set imperatively via `tree.update({ ... })` would be reverted to the parent's React props the next time a node was toggled.

## The fix

Split the effect:

- One `useMemo` syncs from `treeProps` (same as before, minus the open-state dep).
- A second `useMemo` rebuilds visible nodes on `state.nodes.open` changes using `api.props` — preserving any imperative changes.

Backward compatible: when no one calls `api.update()` imperatively, `api.props === treeProps`, so behavior is unchanged.

## Notes

- **Partial fix for #228.** The reporter also noted that `tree.update()` ''does not take effect immediately.'' That's a separate issue — `api.update()` mutates `this.props` but doesn't dispatch a Redux action, so `useSyncExternalStore` doesn't notify. That requires a different fix and isn't in scope here.
- **No regression test.** The repo currently has only a node-environment Jest setup with one `TreeApi` unit test. Reproducing this bug requires React component rendering (jsdom + `@testing-library/react`), which is a larger infra change. Happy to do that in a follow-up if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)