### PR TITLE
Add outerElementType/innerElementType props to Tree

### DIFF
--- a/modules/react-arborist/src/components/default-container.tsx
+++ b/modules/react-arborist/src/components/default-container.tsx
@@ -226,8 +226,8 @@ export function DefaultContainer() {
         itemSize={tree.rowHeight}
         overscanCount={tree.overscanCount}
         itemKey={(index) => tree.visibleNodes[index]?.id || index}
-        outerElementType={ListOuterElement}
-        innerElementType={ListInnerElement}
+        outerElementType={tree.props.outerElementType ?? ListOuterElement}
+        innerElementType={tree.props.innerElementType ?? ListInnerElement}
         onScroll={tree.props.onScroll}
         onItemsRendered={tree.onItemsRendered.bind(tree)}
         ref={tree.list}

--- a/modules/react-arborist/src/components/list-outer-element.tsx
+++ b/modules/react-arborist/src/components/list-outer-element.tsx
@@ -24,7 +24,7 @@ export const ListOuterElement = forwardRef(function Outer(
   );
 });
 
-const DropContainer = () => {
+export const DropContainer = () => {
   const tree = useTreeApi();
   return (
     <div

--- a/modules/react-arborist/src/index.ts
+++ b/modules/react-arborist/src/index.ts
@@ -1,5 +1,8 @@
 /* The Public Api */
 export { Tree } from "./components/tree";
+export { DropContainer } from "./components/list-outer-element";
+export { ListOuterElement } from "./components/list-outer-element";
+export { ListInnerElement } from "./components/list-inner-element";
 export * from "./types/handlers";
 export * from "./types/renderers";
 export * from "./types/state";

--- a/modules/react-arborist/src/types/tree-props.ts
+++ b/modules/react-arborist/src/types/tree-props.ts
@@ -2,7 +2,7 @@ import { BoolFunc } from "./utils";
 import * as handlers from "./handlers";
 import * as renderers from "./renderers";
 import { ElementType, MouseEventHandler } from "react";
-import { ListOnScrollProps } from "react-window";
+import { ListOnScrollProps, CommonProps as ReactWindowCommonProps } from "react-window";
 import { NodeApi } from "../interfaces/node-api";
 import { OpenMap } from "../state/open-slice";
 import { useDragDropManager, DndProviderProps } from "react-dnd";
@@ -82,4 +82,8 @@ export interface TreeProps<T> {
     { backend: unknown }
   >["backend"];
   dndManager?: ReturnType<typeof useDragDropManager>;
+
+  /* Custom react-window outer/inner elements */
+  outerElementType?: ReactWindowCommonProps["outerElementType"];
+  innerElementType?: ReactWindowCommonProps["innerElementType"];
 }


### PR DESCRIPTION
## Summary

Lets consumers supply custom react-window outer/inner wrappers via props, without having to fork `DefaultContainer`. Also exports the default `ListOuterElement`, `ListInnerElement`, and `DropContainer` so a custom outer element can reuse the existing drop-target behavior.

When the new props aren't supplied, behavior is unchanged.

```tsx
<Tree
  outerElementType={MyOuterWithStickyHeader}
  innerElementType={MyInner}
  ...
/>
```

This is the title feature cherry-picked out of #318. That PR also bundled a new padding model, a `scrollTo` rewrite, a `useDndManager` hook, and fork-publishing chores — each worth discussing separately, but none belong here. The author hasn't responded since 2025-10 and is shipping their own published fork, so I'm porting just the cleanly-scoped piece.

Closes #318 in spirit (credit to @jorgedanisc for the original).

## Test plan

- [x] `yarn test` passes in `modules/react-arborist`
- [x] `yarn build` succeeds
- [x] Spot-check that omitting both props still renders normally
- [x] Spot-check a custom `outerElementType` that composes `<DropContainer />` + `{children}` works