### PR TITLE
Let nodes be dragged to external react-dnd drop targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 3.9.0
+
+**Features**
+
+- Tree nodes can now be dragged onto react-dnd drop targets outside the tree. The drag item carries the dragged node's `data`, so an external target accepting the default `"NODE"` type can read it (the tree and the target must share one backend via the `dndManager` prop). A new `dragType` prop on `Tree` (a string or `(node) => string`) lets rows advertise a custom react-dnd item type (#282, also addresses #209/#210)
+
 # Version 3.8.0
 
 **Features**

--- a/README.md
+++ b/README.md
@@ -351,8 +351,22 @@ interface TreeProps<T> {
     { backend: unknown }
   >["backend"];
   dndManager?: ReturnType<typeof useDragDropManager>;
+  dragType?: string | ((node: NodeApi<T>) => string);
 }
 ```
+
+### Dragging Nodes to External Drop Targets
+
+The react-dnd drag item created for each row carries the dragged node's `data`, so a drop target rendered outside the tree can read it:
+
+```tsx
+const [, drop] = useDrop(() => ({
+  accept: "NODE",
+  drop: (item) => console.log(item.data), // the dragged node's data
+}));
+```
+
+The tree and your external target must share one react-dnd backend. Wrap both in a single `DndProvider` and pass its manager to the tree via the `dndManager` prop. By default rows advertise the `"NODE"` item type; set the `dragType` prop (a fixed string, or a function of the node) to advertise a custom type instead. Note that the tree's own drop targets only accept `"NODE"`, so a row given a custom `dragType` is no longer reorderable within the tree.
 
 ## Row Component Props
 

--- a/modules/e2e/cypress/e2e/drag-out-spec.cy.js
+++ b/modules/e2e/cypress/e2e/drag-out-spec.cy.js
@@ -1,0 +1,44 @@
+/* The /drag-out demo renders a tree beside an external react-dnd drop zone.
+   Both share one backend (via the dndManager prop), and the zone accepts the
+   default "NODE" type, so dropping a row onto the zone hands it the dragged
+   node's data — proving the drag item now carries `data`. */
+
+describe("Drag Nodes Out Demo", () => {
+  beforeEach(() => {
+    cy.visit("http://localhost:3000/drag-out");
+    cy.get("[role=treeitem]").as("item");
+  });
+
+  it("renders the tree and an empty drop zone", () => {
+    cy.contains("[role=treeitem]", "Documents");
+    cy.get("[data-testid=drop-zone]").should("contain.text", "Drag any node onto this zone.");
+  });
+
+  it("hands the dragged node's data to an external drop target", () => {
+    // Drag from the node's text, which lives inside the element carrying the
+    // drag handle, so react-dnd's source listener runs and builds the item.
+    dragAndDrop(cy.get("@item").contains("report.txt"), cy.get("[data-testid=drop-zone]"));
+
+    // The zone read item.data.name off the drag item and listed it.
+    cy.get("[data-testid=drop-zone]").should("contain.text", "report.txt");
+  });
+
+  it("still reorders nodes within the tree", () => {
+    // Internal drops keep working because the default "NODE" type is unchanged.
+    cy.contains("[role=treeitem]", "installer.dmg").should("have.css", "top", "128px");
+    dragAndDrop(cy.get("@item").contains("installer.dmg"), cy.get("@item").contains("report.txt"));
+    // installer.dmg moved up near report.txt, so its offset dropped below 128px.
+    cy.get("@item").should("have.length", 5);
+    cy.contains("[role=treeitem]", "installer.dmg").then(($el) => {
+      expect(parseFloat($el.css("top"))).to.be.lessThan(128);
+    });
+  });
+});
+
+function dragAndDrop(src, dst) {
+  const dataTransfer = new DataTransfer();
+  src.trigger("dragstart", { dataTransfer });
+  dst.trigger("dragover", { dataTransfer });
+  dst.trigger("drop", { dataTransfer });
+  dst.trigger("dragend", { dataTransfer });
+}

--- a/modules/react-arborist/src/dnd/drag-hook.test.ts
+++ b/modules/react-arborist/src/dnd/drag-hook.test.ts
@@ -1,0 +1,22 @@
+import { NodeApi } from "../interfaces/node-api";
+import { dragTypeForNode } from "./drag-hook";
+
+/* dragTypeForNode only reads node.data when dragType is a function, so a
+   minimal stub stands in for a real NodeApi. */
+function nodeWith<T>(data: T): NodeApi<T> {
+  return { data } as NodeApi<T>;
+}
+
+test("defaults to the internal NODE type when dragType is undefined", () => {
+  expect(dragTypeForNode(undefined, nodeWith({ id: "a" }))).toBe("NODE");
+});
+
+test("uses a fixed string dragType for every node", () => {
+  expect(dragTypeForNode("FILE", nodeWith({ id: "a" }))).toBe("FILE");
+});
+
+test("resolves a per-node dragType function against the node", () => {
+  const dragType = (node: NodeApi<{ kind: string }>) => node.data.kind.toUpperCase();
+  expect(dragTypeForNode(dragType, nodeWith({ kind: "folder" }))).toBe("FOLDER");
+  expect(dragTypeForNode(dragType, nodeWith({ kind: "file" }))).toBe("FILE");
+});

--- a/modules/react-arborist/src/dnd/drag-hook.ts
+++ b/modules/react-arborist/src/dnd/drag-hook.ts
@@ -23,7 +23,7 @@ export function useDragHook<T>(node: NodeApi<T>): ConnectDragSource {
       canDrag: () => node.isDraggable,
       type: dragTypeForNode(tree.props.dragType, node),
       item: () => {
-        // This is fired once at the begging of a drag operation
+        // This is fired once at the beginning of a drag operation
         const dragIds = tree.isSelected(node.id) ? Array.from(ids) : [node.id];
         tree.dispatch(dnd.dragStart(node.id, dragIds));
         return { id: node.id, dragIds, data: node.data };

--- a/modules/react-arborist/src/dnd/drag-hook.ts
+++ b/modules/react-arborist/src/dnd/drag-hook.ts
@@ -4,21 +4,29 @@ import { getEmptyImage } from "react-dnd-html5-backend";
 import { useTreeApi } from "../context";
 import { NodeApi } from "../interfaces/node-api";
 import { DragItem } from "../types/dnd";
+import { TreeProps } from "../types/tree-props";
 import { DropResult } from "./drop-hook";
 import { actions as dnd } from "../state/dnd-slice";
 
+/* The react-dnd item type a row's drag source broadcasts. The dragType prop
+   can be a fixed string or a per-node function; it defaults to "NODE". */
+export function dragTypeForNode<T>(dragType: TreeProps<T>["dragType"], node: NodeApi<T>): string {
+  if (typeof dragType === "function") return dragType(node);
+  return dragType ?? "NODE";
+}
+
 export function useDragHook<T>(node: NodeApi<T>): ConnectDragSource {
-  const tree = useTreeApi();
+  const tree = useTreeApi<T>();
   const ids = tree.selectedIds;
-  const [_, ref, preview] = useDrag<DragItem, DropResult, void>(
+  const [_, ref, preview] = useDrag<DragItem<T>, DropResult, void>(
     () => ({
       canDrag: () => node.isDraggable,
-      type: "NODE",
+      type: dragTypeForNode(tree.props.dragType, node),
       item: () => {
         // This is fired once at the begging of a drag operation
         const dragIds = tree.isSelected(node.id) ? Array.from(ids) : [node.id];
         tree.dispatch(dnd.dragStart(node.id, dragIds));
-        return { id: node.id, dragIds };
+        return { id: node.id, dragIds, data: node.data };
       },
       end: () => {
         tree.hideCursor();
@@ -26,7 +34,7 @@ export function useDragHook<T>(node: NodeApi<T>): ConnectDragSource {
         tree.dispatch(dnd.dragEnd());
       },
     }),
-    [ids, node],
+    [ids, node, tree.props.dragType],
   );
 
   useEffect(() => {

--- a/modules/react-arborist/src/types/dnd.ts
+++ b/modules/react-arborist/src/types/dnd.ts
@@ -4,6 +4,11 @@ export type CursorLocation = {
   parentId: string | null;
 };
 
-export type DragItem = {
+export type DragItem<T = any> = {
+  /* The id of the row the drag started on. */
   id: string;
+  /* Every node carried by the drag (the selection, or just `id`). */
+  dragIds: string[];
+  /* The dragged node's data, so external drop targets can read it. */
+  data: T;
 };

--- a/modules/react-arborist/src/types/tree-props.ts
+++ b/modules/react-arborist/src/types/tree-props.ts
@@ -79,6 +79,15 @@ export interface TreeProps<T> {
   dndBackend?: Extract<DndProviderProps<unknown, unknown>, { backend: unknown }>["backend"];
   dndManager?: ReturnType<typeof useDragDropManager>;
 
+  /* The react-dnd item type each row's drag source advertises. Defaults to
+     "NODE". Set a custom value (or a per-node function) so rows can be dropped
+     onto external react-dnd targets that accept that type. The dragged node's
+     data is always exposed on the drag item, so an external target accepting
+     the default "NODE" type can read it without setting this. Note: the tree's
+     own drop targets only accept "NODE", so a row given a custom type is no
+     longer reorderable within the tree. */
+  dragType?: string | ((node: NodeApi<T>) => string);
+
   /* Custom react-window outer/inner elements */
   outerElementType?: ReactWindowCommonProps["outerElementType"];
   innerElementType?: ReactWindowCommonProps["innerElementType"];

--- a/modules/showcase/package.json
+++ b/modules/showcase/package.json
@@ -15,6 +15,8 @@
     "next": "^14.0.4",
     "react": "^18.2.0",
     "react-arborist": "workspace:*",
+    "react-dnd": "^14.0.3",
+    "react-dnd-html5-backend": "^14.0.3",
     "react-dom": "^18.2.0",
     "react-icons": "^4.12.0",
     "tree-model-improved": "^2.0.1",

--- a/modules/showcase/pages/drag-out.tsx
+++ b/modules/showcase/pages/drag-out.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react";
+import { NodeRendererProps, Tree } from "react-arborist";
+import { DndProvider, useDragDropManager, useDrop } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
+import Link from "next/link";
+
+type Item = { id: string; name: string; children?: Item[] };
+
+const data: Item[] = [
+  {
+    id: "documents",
+    name: "Documents",
+    children: [
+      { id: "report", name: "report.txt" },
+      { id: "notes", name: "notes.txt" },
+    ],
+  },
+  {
+    id: "downloads",
+    name: "Downloads",
+    children: [{ id: "installer", name: "installer.dmg" }],
+  },
+];
+
+export default function DragOut() {
+  return (
+    <div style={{ padding: 24, fontFamily: "sans-serif" }}>
+      <h1>Drag Nodes Out of the Tree</h1>
+      <p>
+        The dragged node&apos;s data rides along on the react-dnd drag item, so a drop target
+        outside the tree can read it. Both the tree and the drop zone below share one react-dnd
+        backend (via the <code>dndManager</code> prop), and the drop zone accepts the default{" "}
+        <code>&quot;NODE&quot;</code> type. Internal reordering still works.
+      </p>
+      {/* One DndProvider wraps both the tree and the external drop target so they
+          share a backend; the tree reuses it through the dndManager prop. */}
+      <DndProvider backend={HTML5Backend}>
+        <DragOutDemo />
+      </DndProvider>
+      <p style={{ marginTop: 24 }}>
+        <Link href="/">Back to Demos</Link>
+      </p>
+    </div>
+  );
+}
+
+function DragOutDemo() {
+  const manager = useDragDropManager();
+  const [dropped, setDropped] = useState<string[]>([]);
+
+  return (
+    <div style={{ display: "flex", gap: 24, alignItems: "flex-start" }}>
+      <Tree
+        initialData={data}
+        openByDefault
+        width={300}
+        height={300}
+        indent={20}
+        rowHeight={32}
+        dndManager={manager}
+      >
+        {Node}
+      </Tree>
+      <DropZone dropped={dropped} onDrop={(name) => setDropped((prev) => [...prev, name])} />
+    </div>
+  );
+}
+
+function Node({ node, style, dragHandle }: NodeRendererProps<Item>) {
+  return (
+    <div
+      ref={dragHandle}
+      style={{
+        ...style,
+        display: "flex",
+        alignItems: "center",
+        paddingLeft: 8,
+        background: node.isSelected ? "#e0ecff" : undefined,
+        cursor: "grab",
+      }}
+      onClick={() => node.isInternal && node.toggle()}
+    >
+      {node.isInternal ? (node.isOpen ? "📂" : "📁") : "📄"}
+      <span style={{ marginLeft: 6 }}>{node.data.name}</span>
+    </div>
+  );
+}
+
+function DropZone({ dropped, onDrop }: { dropped: string[]; onDrop: (name: string) => void }) {
+  const [{ isOver }, drop] = useDrop<{ data: Item }, void, { isOver: boolean }>(() => ({
+    accept: "NODE",
+    drop: (item) => onDrop(item.data.name),
+    collect: (monitor) => ({ isOver: monitor.isOver() }),
+  }));
+
+  return (
+    <div
+      ref={drop}
+      data-testid="drop-zone"
+      style={{
+        width: 220,
+        minHeight: 300,
+        padding: 12,
+        border: "2px dashed #9aa5b1",
+        borderRadius: 8,
+        background: isOver ? "#eef6ff" : "#fafafa",
+      }}
+    >
+      <b>Dropped here</b>
+      {dropped.length === 0 ? (
+        <p style={{ color: "#9aa5b1" }}>Drag any node onto this zone.</p>
+      ) : (
+        <ul style={{ paddingLeft: 18 }}>
+          {dropped.map((name, i) => (
+            <li key={i}>{name}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/modules/showcase/pages/index.tsx
+++ b/modules/showcase/pages/index.tsx
@@ -62,6 +62,19 @@ const Home: NextPage = () => {
               <Link href="/variable-height">View Demo</Link>
             </div>
           </Link>
+
+          <Link href="/drag-out" legacyBehavior>
+            <div className={styles.demoCard}>
+              <div className={`${styles.demoCardImage} cities`}></div>
+              <b>Cross-Source DnD</b>
+              <h2>Drag Nodes Out</h2>
+              <p>
+                In this demo, we drag nodes onto a drop target outside the tree, which reads the
+                dragged node&apos;s data from the react-dnd item.
+              </p>
+              <Link href="/drag-out">View Demo</Link>
+            </div>
+          </Link>
         </div>
       </main>
     </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9683,6 +9683,8 @@ __metadata:
     npm-run-all: "npm:^4.1.5"
     react: "npm:^18.2.0"
     react-arborist: "workspace:*"
+    react-dnd: "npm:^14.0.3"
+    react-dnd-html5-backend: "npm:^14.0.3"
     react-dom: "npm:^18.2.0"
     react-icons: "npm:^4.12.0"
     rimraf: "npm:^5.0.5"


### PR DESCRIPTION
Reworks #282, scoped to **dragging tree nodes _out_** onto react-dnd drop targets rendered outside the tree. (#282 also tried to make the tree *accept* foreign drops, but that path was incomplete — the drop handler still read internal drag state — so it's left for a separate design.)

## What's included

- **`data` on the drag item.** The react-dnd item created for each row now carries the dragged node's `data` (alongside the existing `dragIds`), so an external target accepting the default `"NODE"` type can read it. This also covers the need behind #209 / #210.
- **`dragType` prop on `Tree`** — a string or `(node) => string` that sets the react-dnd item type a row's drag source advertises. Defaults to `"NODE"`. Useful for routing different node kinds to different external targets. (Caveat, documented: the tree's own drop targets only accept `"NODE"`, so a row given a custom `dragType` is no longer reorderable within the tree.)

## Usage

Wrap the tree and your external target in one `DndProvider` and share the manager via the `dndManager` prop:

```tsx
<DndProvider backend={HTML5Backend}>
  <Tree dndManager={manager} ...>{Node}</Tree>
  <DropZone /> {/* useDrop({ accept: "NODE", drop: (item) => item.data }) */}
</DndProvider>
```

## Validation

- New `/drag-out` showcase demo + Cypress spec (drags a node onto an external zone and asserts the zone receives `item.data`; also confirms internal reordering still works).
- Unit test for the `dragTypeForNode` resolution helper.
- Full suite green: 14 unit tests, 20 e2e tests, oxlint clean, oxfmt clean.
- README docs added.

Supersedes #282; also addresses #209 / #210 (closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)