### PR TITLE
docs: add testing entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,22 @@ yarn add react-arborist
 npm install react-arborist
 ```
 
+## Testing
+
+The package ships with Jest tests under `modules/react-arborist/src/**/*.test.ts?(x)`.
+From the package directory you can run:
+
+```bash
+cd modules/react-arborist
+yarn test
+```
+
+Good starting points:
+
+- `src/interfaces/tree-api.test.ts` for pure API behavior
+- `src/components/provider.test.tsx` for rendered tree behavior
+- `src/dnd/drag-hook.test.ts` for drag-and-drop behavior
+
 ## Examples
 
 Assume our data is this:

--- a/README.md
+++ b/README.md
@@ -34,22 +34,6 @@ yarn add react-arborist
 npm install react-arborist
 ```
 
-## Testing
-
-The package ships with Jest tests under `modules/react-arborist/src/**/*.test.ts?(x)`.
-From the package directory you can run:
-
-```bash
-cd modules/react-arborist
-yarn test
-```
-
-Good starting points:
-
-- `src/interfaces/tree-api.test.ts` for pure API behavior
-- `src/components/provider.test.tsx` for rendered tree behavior
-- `src/dnd/drag-hook.test.ts` for drag-and-drop behavior
-
 ## Examples
 
 Assume our data is this:
@@ -813,6 +797,22 @@ function Node({ node, style }) {
 ```
 
 Pass a partial `chars` object to override any of the default characters (e.g. for an ASCII-only style).
+
+## Contributing
+
+The package ships with Jest tests under `modules/react-arborist/src/**/*.test.ts?(x)`.
+From the package directory you can run:
+
+```bash
+cd modules/react-arborist
+yarn test
+```
+
+Good starting points:
+
+- `src/interfaces/tree-api.test.ts` for pure API behavior
+- `src/components/provider.test.tsx` for rendered tree behavior
+- `src/dnd/drag-hook.test.ts` for drag-and-drop behavior
 
 ## Author
 


### PR DESCRIPTION
## Summary
- document where package tests live
- add the basic Jest command from the package directory
- point contributors to a few representative test files

## Testing
- not run (README-only change)