### PR TITLE
docs: update dynamic sizing example for React 19 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,15 +245,17 @@ function App() {
 
 ### Dynamic sizing
 
-You can add a ref to it with this package [ZeeCoder/use-resize-observer](https://github.com/ZeeCoder/use-resize-observer)
+You can add a ref to it with this package [Pmndrs/react-use-measure](https://github.com/pmndrs/react-use-measure)
  
-That hook will return the height and width of the parent whenever it changes. You then pass these numbers to the Tree.
+That hook will will measure the boundaries (for instance width, height, top, left) of a view you reference. Then you pass the width and the height to the Tree.
 
 ```js
-const { ref, width, height } = useResizeObserver();
+import useMeasure from "react-use-measure";
+
+const [ref, bounds] = useMeasure();
  
 <div className="parent" ref={ref}>
-  <Tree height={height} width={width} />
+  <Tree height={bounds.height} width={bounds.width} />
 </div>
 ```
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ function App() {
 
 You can add a ref to it with this package [Pmndrs/react-use-measure](https://github.com/pmndrs/react-use-measure)
  
-That hook will will measure the boundaries (for instance width, height, top, left) of a view you reference. Then you pass the width and the height to the Tree.
+That hook will measure the boundaries (for instance width, height, top, left) of a view you reference. Then you pass the width and the height to the Tree.
 
 ```js
 import useMeasure from "react-use-measure";


### PR DESCRIPTION
This pull request updates the dynamic sizing example in the `README.md` to use a more modern and widely adopted measurement hook. The documentation now recommends `react-use-measure` instead of `use-resize-observer` and updates the sample code accordingly.

Documentation improvements:

* Replaces the recommendation of `ZeeCoder/use-resize-observer` with `Pmndrs/react-use-measure` for measuring element bounds.
* Updates the example code to use `useMeasure` from `react-use-measure`, reflecting changes in how width and height are accessed and passed to the `Tree` component.