### PR TITLE
Windows Ctrl multi-select and forward aria-label to the tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Version 3.10.0
+
+**Features**
+
+- `aria-label` and `aria-labelledby` props on `Tree` are now forwarded onto the internal `role="tree"` element, giving the tree an accessible name per the W3C Treeview pattern. The element also gains `aria-multiselectable` unless `disableMultiSelection` is set (#325)
+
+**Fixes**
+
+- Mouse multi-selection now responds to Ctrl+Click and Ctrl+A on Windows/Linux, in addition to the existing Cmd (Meta) shortcuts on macOS (#303)
+
 # Version 3.9.0
 
 **Features**

--- a/modules/react-arborist/src/components/default-container.test.tsx
+++ b/modules/react-arborist/src/components/default-container.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { Tree } from "./tree";
+
+type Datum = { id: string; name: string; children?: Datum[] };
+
+const data: Datum[] = [
+  {
+    id: "1",
+    name: "root",
+    children: [
+      { id: "2", name: "a" },
+      { id: "3", name: "b", children: [{ id: "4", name: "c" }] },
+    ],
+  },
+];
+
+/* #303: multi-select should respond to Ctrl+Click (Windows) as well as
+   Cmd/Meta+Click (macOS). */
+test("Ctrl+Click adds a row to the selection (#303)", () => {
+  render(<Tree<Datum> data={data} openByDefault />);
+  const [, a, b] = screen.getAllByRole("treeitem");
+
+  fireEvent.click(a);
+  expect(a.getAttribute("aria-selected")).toBe("true");
+
+  fireEvent.click(b, { ctrlKey: true });
+  expect(a.getAttribute("aria-selected")).toBe("true");
+  expect(b.getAttribute("aria-selected")).toBe("true");
+});
+
+test("Ctrl+Click toggles an already-selected row off (#303)", () => {
+  render(<Tree<Datum> data={data} openByDefault />);
+  const [, a, b] = screen.getAllByRole("treeitem");
+
+  fireEvent.click(a);
+  fireEvent.click(b, { ctrlKey: true });
+  fireEvent.click(b, { ctrlKey: true });
+
+  expect(a.getAttribute("aria-selected")).toBe("true");
+  expect(b.getAttribute("aria-selected")).toBe("false");
+});
+
+test("Ctrl+Click falls through to a plain select when multi-select is disabled (#303)", () => {
+  render(<Tree<Datum> data={data} openByDefault disableMultiSelection />);
+  const [, a, b] = screen.getAllByRole("treeitem");
+
+  fireEvent.click(a);
+  fireEvent.click(b, { ctrlKey: true });
+
+  expect(a.getAttribute("aria-selected")).toBe("false");
+  expect(b.getAttribute("aria-selected")).toBe("true");
+});
+
+/* #325: forward an accessible name and multiselectable state onto the
+   role="tree" element. */
+test("forwards aria-label to the role=tree element (#325)", () => {
+  render(<Tree<Datum> data={data} aria-label="File explorer" />);
+  expect(screen.getByRole("tree").getAttribute("aria-label")).toBe("File explorer");
+});
+
+test("forwards aria-labelledby to the role=tree element (#325)", () => {
+  render(<Tree<Datum> data={data} aria-labelledby="heading-id" />);
+  expect(screen.getByRole("tree").getAttribute("aria-labelledby")).toBe("heading-id");
+});
+
+test("marks the tree aria-multiselectable by default (#325)", () => {
+  render(<Tree<Datum> data={data} />);
+  expect(screen.getByRole("tree").getAttribute("aria-multiselectable")).toBe("true");
+});
+
+test("omits aria-multiselectable when multi-select is disabled (#325)", () => {
+  render(<Tree<Datum> data={data} disableMultiSelection />);
+  expect(screen.getByRole("tree").hasAttribute("aria-multiselectable")).toBe(false);
+});

--- a/modules/react-arborist/src/components/default-container.tsx
+++ b/modules/react-arborist/src/components/default-container.tsx
@@ -19,6 +19,9 @@ export function DefaultContainer() {
   return (
     <div
       role="tree"
+      aria-label={tree.props["aria-label"]}
+      aria-labelledby={tree.props["aria-labelledby"]}
+      aria-multiselectable={!tree.props.disableMultiSelection || undefined}
       style={{
         height: tree.height,
         width: tree.width,
@@ -133,16 +136,16 @@ export function DefaultContainer() {
           }
           return;
         }
-        if (e.key === "a" && e.metaKey && !tree.props.disableMultiSelection) {
+        if (e.key === "a" && (e.metaKey || e.ctrlKey) && !tree.props.disableMultiSelection) {
           e.preventDefault();
           tree.selectAll();
           return;
         }
-        if (e.key === "a" && !e.metaKey && tree.props.onCreate) {
+        if (e.key === "a" && !e.metaKey && !e.ctrlKey && tree.props.onCreate) {
           tree.createLeaf();
           return;
         }
-        if (e.key === "A" && !e.metaKey) {
+        if (e.key === "A" && !e.metaKey && !e.ctrlKey) {
           if (!tree.props.onCreate) return;
           tree.createInternal();
           return;

--- a/modules/react-arborist/src/interfaces/node-api.ts
+++ b/modules/react-arborist/src/interfaces/node-api.ts
@@ -200,7 +200,7 @@ export class NodeApi<T = any> {
   }
 
   handleClick = (e: React.MouseEvent) => {
-    if (e.metaKey && !this.tree.props.disableMultiSelection) {
+    if ((e.metaKey || e.ctrlKey) && !this.tree.props.disableMultiSelection) {
       if (this.isSelected) this.deselect();
       else this.selectMulti();
     } else if (e.shiftKey && !this.tree.props.disableMultiSelection) {

--- a/modules/react-arborist/src/types/tree-props.ts
+++ b/modules/react-arborist/src/types/tree-props.ts
@@ -69,6 +69,10 @@ export interface TreeProps<T> {
   searchTerm?: string;
   searchMatch?: (node: NodeApi<T>, searchTerm: string) => boolean;
 
+  /* Accessibility */
+  "aria-label"?: string;
+  "aria-labelledby"?: string;
+
   /* Extra */
   className?: string | undefined;
   rowClassName?: string | undefined;


### PR DESCRIPTION
## Summary

Two low-effort fixes from issue triage:

### Windows/Linux Ctrl multi-select (closes #303)
Mouse multi-selection only responded to `metaKey` (Cmd on macOS). On Windows/Linux the familiar modifier is Ctrl. `NodeApi.handleClick` now treats `e.metaKey || e.ctrlKey` as the multi-select modifier, and the container's Cmd+A "select all" now also fires on Ctrl+A. The `a`/`A` create shortcuts are guarded against `ctrlKey` so Ctrl+A selects all rather than creating a node.

### Forward `aria-label` / `aria-labelledby` to `role="tree"` (closes #325)
Per the [W3C Treeview pattern](https://www.w3.org/WAI/ARIA/apg/patterns/treeview/), the `role="tree"` element should have an accessible name. New `aria-label` and `aria-labelledby` props on `Tree` are forwarded onto that element. As a bonus, the element now advertises `aria-multiselectable` unless `disableMultiSelection` is set.

### Out of scope
The niche Cmd+ArrowDown "select & activate focused node" shortcut is left macOS-only — Ctrl+Arrow has different conventions on Windows, so that's better handled by the configurable-shortcuts work in #57.

## Test plan
New `default-container.test.tsx` covers:
- Ctrl+Click adds to / toggles off the selection, and falls through to plain select when `disableMultiSelection` is set
- `aria-label` / `aria-labelledby` are forwarded onto `role="tree"`
- `aria-multiselectable` present by default, absent when multi-select is disabled

Full suite: 21 passed. Typecheck, lint, and format all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)