### PR TITLE
Silence act() warnings in container tests; document warning-clean testing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,8 @@ Unit tests live alongside the source in `modules/react-arborist/src/**/*.test.ts
 
 A passing run is not enough — **read the console output and treat warnings as failures to fix, not noise to scroll past.** Jest reports passing tests even when React or the libraries log to `console.error`/`console.warn`, so it's easy to let warnings accumulate. The common offender here is React's "An update to X inside a test was not wrapped in act(...)": some tree interactions (selection, focus) kick off an async `scrollTo`, whose state update resolves on a microtask after the synchronous `act()` scope from `fireEvent`/`render` has already closed. Wrap the interaction (or a trailing flush) in `await act(async () => { … })` so that update lands inside an `act` scope. When you add or change a test, run the whole suite and confirm it is **warning-clean** before pushing.
 
+## Release process
+
 Releases are driven by `bin/release.mjs` (`yarn release`). The script does git checks, runs tests, builds, bumps `modules/react-arborist/package.json`, commits, tags, pushes, and creates a GitHub Release. The tag push triggers `.github/workflows/publish.yml`, which `npm publish`es via OIDC Trusted Publishing — no npm token is involved.
 
 ### Steps

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,11 @@ Or run `yarn start` from the root, which clean-builds the library then runs the 
 
 The same caveat applies to e2e tests: Cypress drives the showcase's static export, so library changes need a library rebuild first.
 
-## Release process
+## Testing
+
+Unit tests live alongside the source in `modules/react-arborist/src/**/*.test.ts(x)` and run on Jest + Testing Library (`yarn workspace react-arborist test`, or `yarn test` from inside the library workspace).
+
+A passing run is not enough — **read the console output and treat warnings as failures to fix, not noise to scroll past.** Jest reports passing tests even when React or the libraries log to `console.error`/`console.warn`, so it's easy to let warnings accumulate. The common offender here is React's "An update to X inside a test was not wrapped in act(...)": some tree interactions (selection, focus) kick off an async `scrollTo`, whose state update resolves on a microtask after the synchronous `act()` scope from `fireEvent`/`render` has already closed. Wrap the interaction (or a trailing flush) in `await act(async () => { … })` so that update lands inside an `act` scope. When you add or change a test, run the whole suite and confirm it is **warning-clean** before pushing.
 
 Releases are driven by `bin/release.mjs` (`yarn release`). The script does git checks, runs tests, builds, bumps `modules/react-arborist/package.json`, commits, tags, pushes, and creates a GitHub Release. The tag push triggers `.github/workflows/publish.yml`, which `npm publish`es via OIDC Trusted Publishing — no npm token is involved.
 

--- a/modules/react-arborist/src/components/default-container.test.tsx
+++ b/modules/react-arborist/src/components/default-container.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { Tree } from "./tree";
 
 type Datum = { id: string; name: string; children?: Datum[] };
@@ -14,38 +14,48 @@ const data: Datum[] = [
   },
 ];
 
+/* Selecting a row kicks off tree.scrollTo(), whose promise resolves on a
+   microtask after fireEvent's synchronous act() scope has exited — the
+   resulting List scrollToItem() update would otherwise warn about not being
+   wrapped in act(). Awaiting an async act flushes that trailing update. */
+async function click(el: Element, init?: MouseEventInit) {
+  await act(async () => {
+    fireEvent.click(el, init);
+  });
+}
+
 /* #303: multi-select should respond to Ctrl+Click (Windows) as well as
    Cmd/Meta+Click (macOS). */
-test("Ctrl+Click adds a row to the selection (#303)", () => {
+test("Ctrl+Click adds a row to the selection (#303)", async () => {
   render(<Tree<Datum> data={data} openByDefault />);
   const [, a, b] = screen.getAllByRole("treeitem");
 
-  fireEvent.click(a);
+  await click(a);
   expect(a.getAttribute("aria-selected")).toBe("true");
 
-  fireEvent.click(b, { ctrlKey: true });
+  await click(b, { ctrlKey: true });
   expect(a.getAttribute("aria-selected")).toBe("true");
   expect(b.getAttribute("aria-selected")).toBe("true");
 });
 
-test("Ctrl+Click toggles an already-selected row off (#303)", () => {
+test("Ctrl+Click toggles an already-selected row off (#303)", async () => {
   render(<Tree<Datum> data={data} openByDefault />);
   const [, a, b] = screen.getAllByRole("treeitem");
 
-  fireEvent.click(a);
-  fireEvent.click(b, { ctrlKey: true });
-  fireEvent.click(b, { ctrlKey: true });
+  await click(a);
+  await click(b, { ctrlKey: true });
+  await click(b, { ctrlKey: true });
 
   expect(a.getAttribute("aria-selected")).toBe("true");
   expect(b.getAttribute("aria-selected")).toBe("false");
 });
 
-test("Ctrl+Click falls through to a plain select when multi-select is disabled (#303)", () => {
+test("Ctrl+Click falls through to a plain select when multi-select is disabled (#303)", async () => {
   render(<Tree<Datum> data={data} openByDefault disableMultiSelection />);
   const [, a, b] = screen.getAllByRole("treeitem");
 
-  fireEvent.click(a);
-  fireEvent.click(b, { ctrlKey: true });
+  await click(a);
+  await click(b, { ctrlKey: true });
 
   expect(a.getAttribute("aria-selected")).toBe("false");
   expect(b.getAttribute("aria-selected")).toBe("true");


### PR DESCRIPTION
## Summary

Follow-up cleanup for the tests added by https://github.com/jameskerr/react-arborist/pull/354

The Ctrl+Click tests in `default-container.test.tsx` selected rows, which kicks off an async `tree.scrollTo()` (tree-api.ts:409 → 638). Its `List.scrollToItem()` state update resolves on a microtask **after** the synchronous `act()` scope from `fireEvent` has already closed, so React logged six `An update to List inside a test was not wrapped in act(...)` warnings. The tests still passed, but the console noise is easy to let accumulate.

- Route the selecting clicks through a small `await act(async () => …)` helper that flushes the trailing scroll update inside an `act` scope. No behavior change — purely a test-timing fix. **Warnings: 6 → 0.**
- Add an **AGENTS.md "Testing"** section telling agents to read console output and treat warnings as something to fix (not just confirm tests pass) before pushing, with this `act`/`scrollTo` case called out as the common offender.

## Test plan
`yarn workspace react-arborist test` — 21 passed, **0 console warnings**. Typecheck, lint, and format all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)