### PR TITLE
Assemble CHANGELOG from per-PR changesets

### DIFF
--- a/.changes/README.md
+++ b/.changes/README.md
@@ -1,0 +1,52 @@
+# Changesets
+
+Each user-facing change gets a small Markdown file in this directory describing
+it. At release time, `bin/release.mjs` (`yarn release`) collects every entry,
+infers the version bump, assembles the new `# Version X.Y.Z` section at the top
+of [`CHANGELOG.md`](../CHANGELOG.md), and deletes the files it consumed.
+
+Because each PR adds its own file, changelog entries never conflict and PRs can
+merge in any order — no one has to pick the next version number up front.
+
+## Adding an entry
+
+Create `.changes/<short-slug>.md` (the slug is yours to choose; e.g.
+`303-ctrl-multiselect.md`):
+
+```markdown
+---
+type: fix
+pr: 303
+---
+Mouse multi-selection now responds to Ctrl+Click and Ctrl+A on Windows/Linux,
+in addition to the existing Cmd (Meta) shortcuts on macOS.
+```
+
+### Frontmatter
+
+| Field    | Required | Meaning                                                                 |
+| -------- | -------- | ----------------------------------------------------------------------- |
+| `type`   | yes      | `breaking`, `feature`, or `fix`. Picks the changelog subsection.        |
+| `pr`     | yes      | This PR's number. Rendered as the trailing `(#NNN)`.                    |
+| `credit` | no       | An earlier PR this supersedes. Rendered as `(#NNN, originally #MMM)`.   |
+
+The body (everything after the closing `---`) is the changelog bullet text and
+may span multiple lines.
+
+### How `type` maps to the release
+
+- `breaking` → **major** bump, under `**Breaking Changes**`
+- `feature` → **minor** bump, under `**Features**`
+- `fix` → **patch** bump, under `**Fixes**`
+
+The release takes the largest bump across all pending changesets. `yarn release`
+needs no version argument, but you can still pass `patch|minor|major|X.Y.Z` to
+override the inferred bump.
+
+## When an entry isn't needed
+
+Refactors, test-only, CI, or docs changes that don't touch published behavior
+don't need a changeset. Apply the `skip-changelog` label to the PR and CI's
+changeset check will pass.
+
+`README.md` (this file) is ignored by the release script.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+## Summary
+
+<!-- What does this change and why? -->
+
+## Checklist
+
+- [ ] Added a `.changes/` entry describing the change (see `.changes/README.md`),
+      or applied the `skip-changelog` label if it has no user-facing effect.
+- [ ] `yarn lint`, `yarn fmt:check`, and `yarn workspace react-arborist test` pass
+      (warning-clean — see `AGENTS.md`).

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -1,0 +1,34 @@
+name: Changeset
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  changeset:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changelog') }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Require a changeset for library source changes
+        env:
+          BASE: ${{ github.base_ref }}
+        run: |
+          changed=$(git diff --name-only "origin/$BASE...HEAD")
+          touches_src=$(echo "$changed" | grep -E '^modules/react-arborist/src/' || true)
+          if [ -z "$touches_src" ]; then
+            echo "No library source changes — changeset not required."
+            exit 0
+          fi
+          added=$(git diff --name-only --diff-filter=A "origin/$BASE...HEAD" \
+            | grep -E '^\.changes/.+\.md$' | grep -v '^\.changes/README\.md$' || true)
+          if [ -n "$added" ]; then
+            echo "Found changeset(s):"
+            echo "$added"
+            exit 0
+          fi
+          echo "::error::This PR changes modules/react-arborist/src/ but adds no .changes/ entry."
+          echo "Add a changeset (see .changes/README.md) describing the change, or apply the"
+          echo "'skip-changelog' label if it has no user-facing effect."
+          exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,8 @@ Other notable files:
 
 - `bin/release.mjs` — release orchestration script, driven by `yarn release`. Bumps the version and pushes a tag; the tag push is what kicks off publishing.
 - `bin/publish` — the actual npm publish step. Builds the library, copies `README.md` into the library workspace, then `npm publish`es from there. Invoked from CI by `.github/workflows/publish.yml` on tag push; also runnable by hand.
-- `CHANGELOG.md` — release notes. The release script reads the `# Version X.Y.Z` section from here and refuses to release if it's missing.
+- `CHANGELOG.md` — release notes. **No longer hand-edited per change.** The release script assembles a new `# Version X.Y.Z` section here from the pending entries in `.changes/` (see below).
+- `.changes/` — one Markdown file per user-facing change (the "changeset"). Each PR adds its own file, so entries never conflict and PRs merge in any order. `bin/release.mjs` consumes them at release time. Format is documented in `.changes/README.md`.
 
 ## Tooling
 
@@ -58,14 +59,15 @@ Releases are driven by `bin/release.mjs` (`yarn release`). The script does git c
 ### Steps
 
 1. On `main`, working tree clean, in sync with the remote.
-2. Add a `# Version X.Y.Z` section at the top of `CHANGELOG.md` for the upcoming version, with `**Features**` / `**Fixes**` subsections. Each bullet should end with the PR number in parens, e.g. `(#342)`. Commit and push. (Often this entry lands as part of the feature PR itself — check `CHANGELOG.md` before adding a new commit.)
-3. Run `yarn release <patch|minor|major|X.Y.Z>`. The script:
+2. Confirm the pending changes have `.changes/` entries (they normally land with their PRs). You do **not** hand-edit `CHANGELOG.md` — the script writes it.
+3. Run `yarn release` (no version argument needed — the bump is inferred). The script:
    - Verifies branch is `main`, working tree is clean, local matches remote.
    - Runs `yarn workspace react-arborist test` and `yarn build-lib`.
-   - Reads the matching `# Version X.Y.Z` section from `CHANGELOG.md` — **fails if missing**.
-   - Bumps `modules/react-arborist/package.json`, commits as `vX.Y.Z`, tags `vX.Y.Z`.
+   - Reads `.changes/*.md` — **fails if there are none**. Infers the bump from the entry types (`breaking` → major, `feature` → minor, `fix` → patch; takes the largest). Pass an explicit `patch|minor|major|X.Y.Z` only to override.
+   - Assembles a new `# Version X.Y.Z` section and prepends it to `CHANGELOG.md`, then `git rm`s the consumed `.changes/` files.
+   - Bumps `modules/react-arborist/package.json`, commits as `vX.Y.Z` (changelog + deletions + version in one commit), tags `vX.Y.Z`.
    - Pushes the commit and tag to the tracking remote.
-   - Creates a GitHub Release using the changelog section as the body.
+   - Creates a GitHub Release using the assembled section as the body.
 4. `gh run watch` to watch the publish workflow. Confirm the new version on <https://www.npmjs.com/package/react-arborist>.
 
 ### Flags
@@ -77,11 +79,11 @@ Releases are driven by `bin/release.mjs` (`yarn release`). The script does git c
 
 ### Agent guidance
 
-Agents should **not** run `yarn release` themselves — it pushes tags, mutates npm, and creates a public GitHub Release. The maintainer cuts releases. An agent's job around a release is typically:
+Agents should **not** run `yarn release` themselves — it pushes tags, mutates npm, and creates a public GitHub Release. The maintainer cuts releases. An agent's job around a change is typically:
 
-- Add or refine the `# Version X.Y.Z` entry in `CHANGELOG.md`.
-- Confirm `main` has all the PRs that should be in the release.
-- Optionally run `yarn release <kind> --preview` to verify the script's preconditions pass.
+- Add a `.changes/` entry for the change (see `.changes/README.md`) — **not** edit `CHANGELOG.md` directly. A PR that touches `modules/react-arborist/src/` without one fails the `Changeset` CI check; apply the `skip-changelog` label for changes with no user-facing effect.
+- Confirm `main` has all the PRs (and their changesets) that should be in the release.
+- Optionally run `yarn release --preview` (add `--any-branch --no-tests` off `main`) to verify the inferred bump and the assembled notes look right.
 
 ## Conventions
 

--- a/bin/release.mjs
+++ b/bin/release.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
-import { readFileSync, writeFileSync } from "node:fs";
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { createInterface } from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
 import os from "node:os";
@@ -10,6 +10,16 @@ import { fileURLToPath } from "node:url";
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const pkgPath = path.join(rootDir, "modules/react-arborist/package.json");
 const changelogPath = path.join(rootDir, "CHANGELOG.md");
+const changesDir = path.join(rootDir, ".changes");
+
+/* type → { changelog heading, bump rank }. Headings match the existing
+   CHANGELOG.md sections; rank picks the largest bump across all changesets. */
+const TYPES = {
+  breaking: { heading: "**Breaking Changes**", rank: 3 },
+  feature: { heading: "**Features**", rank: 2 },
+  fix: { heading: "**Fixes**", rank: 1 },
+};
+const RANK_TO_BUMP = { 3: "major", 2: "minor", 1: "patch" };
 
 const args = process.argv.slice(2);
 const flags = {
@@ -50,18 +60,51 @@ function bump(current, kind) {
   fail(`Invalid version: "${kind}". Use patch, minor, major, or X.Y.Z.`);
 }
 
-function readChangelogSection(version) {
-  const content = readFileSync(changelogPath, "utf8");
-  const escaped = version.replace(/\./g, "\\.");
-  const re = new RegExp(`^# Version ${escaped}\\s*\\n([\\s\\S]*?)(?=^# Version |\\Z)`, "m");
-  const match = content.match(re);
-  return match ? match[1].trim() : null;
+/* Read every .changes/*.md (except README.md) and parse its frontmatter. Each
+   file is a `--- key: value --- body` document; no YAML dep needed. */
+function readChangesets() {
+  let files;
+  try {
+    files = readdirSync(changesDir);
+  } catch {
+    return [];
+  }
+  return files
+    .filter((f) => f.endsWith(".md") && f !== "README.md")
+    .map((f) => {
+      const raw = readFileSync(path.join(changesDir, f), "utf8");
+      const m = raw.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
+      if (!m) fail(`Malformed changeset ${f}: expected frontmatter between --- fences.`);
+      const meta = {};
+      for (const line of m[1].split("\n")) {
+        const kv = line.match(/^\s*([A-Za-z]+)\s*:\s*(.+?)\s*$/);
+        if (kv) meta[kv[1]] = kv[2];
+      }
+      if (!TYPES[meta.type]) {
+        fail(
+          `Changeset ${f}: type must be one of ${Object.keys(TYPES).join(", ")} (got "${meta.type}").`,
+        );
+      }
+      if (!meta.pr) fail(`Changeset ${f}: missing "pr".`);
+      const body = m[2].trim();
+      if (!body) fail(`Changeset ${f}: body is empty.`);
+      return { type: meta.type, pr: meta.pr, credit: meta.credit, body, file: f };
+    });
 }
 
-if (!versionArg) {
-  fail(
-    "Usage: yarn release <patch|minor|major|X.Y.Z> [--preview] [--any-branch] [--no-tests] [--yes]",
-  );
+/* Build the `# Version X.Y.Z` block plus the body alone (for the GH release). */
+function renderSection(version, changesets) {
+  const parts = [];
+  for (const type of Object.keys(TYPES)) {
+    const entries = changesets.filter((c) => c.type === type);
+    if (entries.length === 0) continue;
+    const bullets = entries
+      .map((c) => `- ${c.body} (#${c.pr}${c.credit ? `, originally #${c.credit}` : ""})`)
+      .join("\n");
+    parts.push(`${TYPES[type].heading}\n\n${bullets}`);
+  }
+  const body = parts.join("\n\n");
+  return { body, block: `# Version ${version}\n\n${body}\n` };
 }
 
 step("Checking branch");
@@ -106,22 +149,31 @@ if (!flags.skipTests) {
 step("Building library");
 run("yarn build-lib");
 
+const changesets = readChangesets();
+if (changesets.length === 0) {
+  fail("No changesets in .changes/. Add a `.changes/*.md` entry before releasing.");
+}
+
 const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
 const oldVersion = pkg.version;
-const newVersion = bump(oldVersion, versionArg);
+// Derive the bump from the changeset types; an explicit arg overrides it.
+const maxRank = Math.max(...changesets.map((c) => TYPES[c.type].rank));
+const kind = versionArg ?? RANK_TO_BUMP[maxRank];
+const newVersion = bump(oldVersion, kind);
 const tag = `v${newVersion}`;
 
-console.log(`\nVersion: ${oldVersion} → ${newVersion}  (tag: ${tag})`);
+console.log(
+  `\nVersion: ${oldVersion} → ${newVersion}  (tag: ${tag}, ${versionArg ? "explicit" : "inferred"} ${kind})`,
+);
 
 if (out(`git tag -l ${tag}`)) {
   fail(`Tag ${tag} already exists.`);
 }
 
-const releaseNotes = readChangelogSection(newVersion);
-if (!releaseNotes) {
-  fail(`No "# Version ${newVersion}" section found in CHANGELOG.md. Add one before releasing.`);
-}
-console.log(`\nRelease notes (from CHANGELOG.md):\n${releaseNotes}\n`);
+const { body: releaseNotes, block: changelogBlock } = renderSection(newVersion, changesets);
+console.log(
+  `\nRelease notes (assembled from ${changesets.length} changeset(s)):\n${releaseNotes}\n`,
+);
 
 if (!flags.preview && !flags.yes) {
   const rl = createInterface({ input, output });
@@ -139,6 +191,18 @@ if (flags.preview) {
 } else {
   pkg.version = newVersion;
   writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+}
+
+step(`Prepending "# Version ${newVersion}" to CHANGELOG.md`);
+if (flags.preview) {
+  console.log(`  [preview] prepend assembled section`);
+} else {
+  writeFileSync(changelogPath, `${changelogBlock}\n${readFileSync(changelogPath, "utf8")}`);
+}
+
+step(`Consuming ${changesets.length} changeset(s)`);
+for (const c of changesets) {
+  run(`git rm --quiet ${path.join(".changes", c.file)}`);
 }
 
 step("Committing");


### PR DESCRIPTION
## Summary

Replaces the hand-edited `# Version X.Y.Z` changelog section with a **changeset** workflow: each PR drops a small file in `.changes/`, and `yarn release` assembles `CHANGELOG.md` from them. PRs no longer collide on the top of `CHANGELOG.md` and can merge in any order, and the version number is derived at release time instead of being chosen up front.

### How it works

- **`.changes/<slug>.md`** — one file per user-facing change, with frontmatter `type` (`breaking`/`feature`/`fix`), `pr`, and optional `credit`, plus a body bullet. Format documented in `.changes/README.md`.
- **`bin/release.mjs`** now:
  - collects `.changes/*.md` (ignoring `README.md`), failing if there are none;
  - **infers the bump** from the entry types (`breaking`→major, `feature`→minor, `fix`→patch; largest wins). An explicit `yarn release <patch|minor|major|X.Y.Z>` still overrides;
  - groups entries into the existing `**Breaking Changes**`/`**Features**`/`**Fixes**` headings, prepends the new `# Version X.Y.Z` block to `CHANGELOG.md`, and `git rm`s the consumed files — all in the single `vX.Y.Z` commit.
- **`.github/workflows/changeset.yml`** — fails a PR that touches `modules/react-arborist/src/**` without adding a `.changes/` entry; the `skip-changelog` label bypasses it (for refactors/CI/docs-only changes).
- **`.github/pull_request_template.md`** (new) and **`AGENTS.md`** point contributors and agents at changesets instead of editing `CHANGELOG.md` directly.

Existing `CHANGELOG.md` history (v3.10.0 and earlier) is untouched; the script only prepends going forward.

## Test plan

All exercised via `--preview` (no real release cut):

- fix + feature changesets → inferred **minor** bump (3.10.0 → 3.11.0), correct subsections, `(#303, originally #290)` credit formatting.
- `yarn release major --preview` → 4.0.0 (explicit override).
- empty `.changes/` → fails with an "add an entry" message.
- CI gate shell logic: src-without-changeset → FAIL; src-with-changeset → PASS; `.changes/README.md`-only → FAIL; docs-only → PASS.
- `yarn lint` and `yarn fmt:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)