### PR TITLE
Fire onSelect once in selectAll/deselectAll

### DIFF
--- a/.changes/357-onselect-double-fire.md
+++ b/.changes/357-onselect-double-fire.md
@@ -1,0 +1,7 @@
+---
+type: fix
+pr: 357
+---
+`selectAll()` and `deselectAll()` no longer fire `onSelect` twice. They go
+through `setSelection()`, which already invokes the callback, so consumers now
+see a single `onSelect` per Cmd-A or clear-selection action.

--- a/modules/react-arborist/src/interfaces/tree-api.test.ts
+++ b/modules/react-arborist/src/interfaces/tree-api.test.ts
@@ -48,3 +48,62 @@ test("variable rowHeight function", () => {
   // Out-of-range index falls back to the default height, never an invalid 0.
   expect(api.rowHeightAt(99)).toBe(24);
 });
+
+describe("onSelect fires exactly once per selection method (#332)", () => {
+  function setupWithSpy() {
+    const onSelect = jest.fn();
+    const api = setupApi({ data: rowData, onSelect });
+    return { api, onSelect };
+  }
+
+  test("setSelection", () => {
+    const { api, onSelect } = setupWithSpy();
+    api.setSelection({ ids: ["a"], anchor: "a", mostRecent: "a" });
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  test("select", () => {
+    const { api, onSelect } = setupWithSpy();
+    api.select("a");
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  test("selectMulti", () => {
+    const { api, onSelect } = setupWithSpy();
+    api.selectMulti("a");
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  test("selectContiguous", () => {
+    const { api, onSelect } = setupWithSpy();
+    api.select("a");
+    onSelect.mockClear();
+    api.selectContiguous("c");
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  test("selectAll", () => {
+    const { api, onSelect } = setupWithSpy();
+    api.selectAll();
+    expect(api.selectedIds.size).toBe(3);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  test("deselectAll", () => {
+    const { api, onSelect } = setupWithSpy();
+    api.selectAll();
+    onSelect.mockClear();
+    api.deselectAll();
+    expect(api.selectedIds.size).toBe(0);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  test("deselect", () => {
+    const { api, onSelect } = setupWithSpy();
+    api.selectMulti("a");
+    api.selectMulti("b");
+    onSelect.mockClear();
+    api.deselect("a");
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/modules/react-arborist/src/interfaces/tree-api.ts
+++ b/modules/react-arborist/src/interfaces/tree-api.ts
@@ -455,12 +455,13 @@ export class TreeApi<T> {
   }
 
   deselectAll() {
+    // setSelection fires onSelect; don't fire it again here (see #332).
     this.setSelection({ ids: [], anchor: null, mostRecent: null });
-    safeRun(this.props.onSelect, this.selectedNodes);
   }
 
   selectAll() {
     const allSelectableNodes = this.filterSelectableNodes(Object.keys(this.idToIndex));
+    // setSelection fires onSelect; don't fire it again here (see #332).
     this.setSelection({
       ids: allSelectableNodes,
       anchor: allSelectableNodes[0] ?? null,
@@ -468,7 +469,6 @@ export class TreeApi<T> {
     });
     this.dispatch(focus(this.lastNode?.id));
     if (this.focusedNode) safeRun(this.props.onFocus, this.focusedNode);
-    safeRun(this.props.onSelect, this.selectedNodes);
   }
 
   private filterSelectableNodes(nodes: (IdObj | string)[]) {


### PR DESCRIPTION
## Summary

Fixes #332. `setSelection()` already calls `safeRun(onSelect, ...)`, but `selectAll()` and `deselectAll()` went through `setSelection()` **and** fired `onSelect` again, so consumers saw two `onSelect` callbacks for a single Cmd-A or clear-selection action. This makes `setSelection()` the single source of truth and removes the redundant calls.

The other selection-mutating methods were already single-fire and are left as-is:
- `select()` goes through `setSelection()` and does not re-fire (fixed earlier in #331).
- `deselect()`, `selectMulti()`, `selectContiguous()` dispatch directly (not via `setSelection()`) and fire `onSelect` once.

## Test plan

Added `interfaces/tree-api.test.ts` cases asserting `onSelect` fires exactly once per call for every public selection method (`setSelection`, `select`, `selectMulti`, `selectContiguous`, `selectAll`, `deselectAll`, `deselect`). Full suite is warning-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)