### PR TITLE
Extend row highlight across horizontal overflow (#10)

### DIFF
--- a/.changes/358-row-highlight-overflow.md
+++ b/.changes/358-row-highlight-overflow.md
@@ -1,0 +1,8 @@
+---
+type: fix
+pr: 358
+---
+A row's background and selection highlight now span the full scrollable width
+instead of stopping at the viewport edge. Previously a deeply nested or long
+node that overflowed horizontally would clip the highlight (issue #10);
+`min-width: max-content` is now applied to each row.

--- a/modules/react-arborist/src/components/default-container.test.tsx
+++ b/modules/react-arborist/src/components/default-container.test.tsx
@@ -61,6 +61,15 @@ test("Ctrl+Click falls through to a plain select when multi-select is disabled (
   expect(b.getAttribute("aria-selected")).toBe("true");
 });
 
+/* #10: a row's background/selection highlight must span the full scrollable
+   width, not stop at the viewport edge, when content overflows horizontally. */
+test("rows get min-width: max-content so the highlight spans overflow (#10)", () => {
+  render(<Tree<Datum> data={data} openByDefault />);
+  for (const row of screen.getAllByRole("treeitem")) {
+    expect((row as HTMLElement).style.minWidth).toBe("max-content");
+  }
+});
+
 /* #325: forward an accessible name and multiselectable state onto the
    role="tree" element. */
 test("forwards aria-label to the role=tree element (#325)", () => {

--- a/modules/react-arborist/src/components/row-container.tsx
+++ b/modules/react-arborist/src/components/row-container.tsx
@@ -48,6 +48,12 @@ export const RowContainer = React.memo(function RowContainer<T>({ index, style }
     () => ({
       ...style,
       top: parseFloat(style.top as string) + (tree.props.padding ?? tree.props.paddingTop ?? 0),
+      // react-window gives the row width: 100% of the viewport. When a deeply
+      // nested (or long) node overflows horizontally, that clips the row's
+      // background/selection highlight at the viewport edge. min-width:
+      // max-content lets the row grow with its content so the highlight spans
+      // the full scrollable width (#10).
+      minWidth: "max-content",
     }),
     [style, tree.props.padding, tree.props.paddingTop],
   );


### PR DESCRIPTION
## Summary

Fixes #10. react-window sizes each row at `width: 100%` of the viewport. When a deeply nested (or long) node overflows the tree horizontally, the row's background/selection highlight stops at the viewport edge instead of spanning the full scrollable width — so a selected nested node looks half-highlighted once you scroll right.

Adding `min-width: max-content` to the row's inline style lets the row grow with its content, so the highlight spans the full width. This is the fix the maintainer identified in the issue thread.

## Changes

- `row-container.tsx`: add `minWidth: "max-content"` to the memoized `rowStyle` applied to each `treeitem`.

## Test plan

- New render test in `default-container.test.tsx` asserts every `treeitem` carries `min-width: max-content`.
- Full library suite green (29 tests), `yarn lint` and `yarn fmt:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)