### PR TITLE
Manually create CHANGELOG entry for 3.10.1

### DIFF
--- a/.changes/357-onselect-double-fire.md
+++ b/.changes/357-onselect-double-fire.md
@@ -1,7 +1,0 @@
----
-type: fix
-pr: 357
----
-`selectAll()` and `deselectAll()` no longer fire `onSelect` twice. They go
-through `setSelection()`, which already invokes the callback, so consumers now
-see a single `onSelect` per Cmd-A or clear-selection action.

--- a/.changes/358-row-highlight-overflow.md
+++ b/.changes/358-row-highlight-overflow.md
@@ -1,8 +1,0 @@
----
-type: fix
-pr: 358
----
-A row's background and selection highlight now span the full scrollable width
-instead of stopping at the viewport edge. Previously a deeply nested or long
-node that overflowed horizontally would clip the highlight (issue #10);
-`min-width: max-content` is now applied to each row.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Fixes**
 
-- selectAll() and deselectAll() no longer fire onSelect twice. They go through setSelection(), which already invokes the callback, so consumers now see a single onSelect per Cmd-A or clear-selection action. (#357)
+- `selectAll()` and `deselectAll()` no longer fire `onSelect` twice. They go through `setSelection()`, which already invokes the callback, so consumers now see a single `onSelect` per Cmd+A or clear-selection action. (#357)
 - A row's background and selection highlight now span the full scrollable width instead of stopping at the viewport edge. Previously a deeply nested or long node that overflowed horizontally would clip the highlight (issue #10); `min-width: max-content` is now applied to each row. (#358)
 
 # Version 3.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Version 3.10.1
+
+**Fixes**
+
+- selectAll() and deselectAll() no longer fire onSelect twice. They go through setSelection(), which already invokes the callback, so consumers now see a single onSelect per Cmd-A or clear-selection action. (#357)
+- A row's background and selection highlight now span the full scrollable width instead of stopping at the viewport edge. Previously a deeply nested or long node that overflowed horizontally would clip the highlight (issue #10); `min-width: max-content` is now applied to each row. (#358)
+
 # Version 3.10.0
 
 **Features**


### PR DESCRIPTION
Due to a glitch, v3.10.1 was tagged and released without a corresponding CHANGELOG entry. This PR creates that entry, referencing the two fixes that were included:

* #357
* #358