### PR TITLE
Fire onMove when dropping below the last row (#313)

### DIFF
--- a/.changes/313-drop-bottom-of-list.md
+++ b/.changes/313-drop-bottom-of-list.md
@@ -1,0 +1,10 @@
+---
+type: fix
+pr: 361
+credit: 313
+---
+Dropping a dragged node in the empty area below the last row fires `onMove`
+again. The drop logic had been moved into the per-row drop hook but never added
+to the outer (bottom-of-list) drop target, so drops to the very bottom of the
+tree were silently ignored. The shared handler now lives on `tree.drop()` and is
+used by both drop targets.

--- a/.changes/313-drop-bottom-of-list.md
+++ b/.changes/313-drop-bottom-of-list.md
@@ -1,10 +1,9 @@
 ---
 type: fix
 pr: 361
-credit: 313
 ---
 Dropping a dragged node in the empty area below the last row fires `onMove`
-again. The drop logic had been moved into the per-row drop hook but never added
-to the outer (bottom-of-list) drop target, so drops to the very bottom of the
-tree were silently ignored. The shared handler now lives on `tree.drop()` and is
-used by both drop targets.
+again (issue #313). The drop logic had been moved into the per-row drop hook but
+never added to the outer (bottom-of-list) drop target, so drops to the very
+bottom of the tree were silently ignored. The shared handler now lives on
+`tree.drop()` and is used by both drop targets.

--- a/modules/react-arborist/src/dnd/drop-hook.ts
+++ b/modules/react-arborist/src/dnd/drop-hook.ts
@@ -5,8 +5,6 @@ import { NodeApi } from "../interfaces/node-api";
 import { DragItem } from "../types/dnd";
 import { computeDrop } from "./compute-drop";
 import { actions as dnd } from "../state/dnd-slice";
-import { safeRun } from "../utils";
-import { ROOT_ID } from "../data/create-root";
 
 export type DropResult = {
   parentId: string | null;
@@ -43,15 +41,7 @@ export function useDropHook(
       },
       drop: (_, m) => {
         if (!m.canDrop()) return null;
-        let { parentId, index, dragIds } = tree.state.dnd;
-        safeRun(tree.props.onMove, {
-          dragIds,
-          parentId: parentId === ROOT_ID ? null : parentId,
-          index: index === null ? 0 : index, // When it's null it was dropped over a folder
-          dragNodes: tree.dragNodes,
-          parentNode: tree.get(parentId),
-        });
-        tree.open(parentId);
+        tree.drop();
       },
     }),
     [node, el.current, tree.props],

--- a/modules/react-arborist/src/dnd/outer-drop-hook.ts
+++ b/modules/react-arborist/src/dnd/outer-drop-hook.ts
@@ -36,6 +36,11 @@ export function useOuterDrop() {
           tree.hideCursor();
         }
       },
+      drop: (_item, m) => {
+        if (!m.isOver({ shallow: true })) return null;
+        if (!m.canDrop()) return null;
+        tree.drop();
+      },
     }),
     [tree],
   );

--- a/modules/react-arborist/src/interfaces/tree-api.test.ts
+++ b/modules/react-arborist/src/interfaces/tree-api.test.ts
@@ -1,5 +1,6 @@
 import { createStore } from "redux";
 import { rootReducer } from "../state/root-reducer";
+import { actions as dnd } from "../state/dnd-slice";
 import { TreeProps } from "../types/tree-props";
 import { TreeApi } from "./tree-api";
 
@@ -15,6 +16,30 @@ test("tree.canDrop()", () => {
 });
 
 const rowData = [{ id: "a" }, { id: "b" }, { id: "c" }];
+
+describe("tree.drop() fires onMove (#313)", () => {
+  test("reports the hovered parent and index", () => {
+    const onMove = jest.fn();
+    const api = setupApi({ data: rowData, onMove });
+    // Simulate hovering the bottom drop zone: root parent, index past the end.
+    api.dispatch(dnd.dragStart("a", ["a"]));
+    api.dispatch(dnd.hovering(null, 3));
+    api.drop();
+    expect(onMove).toHaveBeenCalledTimes(1);
+    expect(onMove).toHaveBeenCalledWith(
+      expect.objectContaining({ dragIds: ["a"], parentId: null, index: 3 }),
+    );
+  });
+
+  test("coerces a null index (dropped onto a folder) to 0", () => {
+    const onMove = jest.fn();
+    const api = setupApi({ data: rowData, onMove });
+    api.dispatch(dnd.dragStart("a", ["a"]));
+    api.dispatch(dnd.hovering(null, null));
+    api.drop();
+    expect(onMove).toHaveBeenCalledWith(expect.objectContaining({ index: 0 }));
+  });
+});
 
 test("rowHeight defaults to 24", () => {
   const api = setupApi({});

--- a/modules/react-arborist/src/interfaces/tree-api.test.ts
+++ b/modules/react-arborist/src/interfaces/tree-api.test.ts
@@ -18,12 +18,13 @@ test("tree.canDrop()", () => {
 const rowData = [{ id: "a" }, { id: "b" }, { id: "c" }];
 
 describe("tree.drop() fires onMove (#313)", () => {
-  test("reports the hovered parent and index", () => {
+  test("reports the hovered parent and index, mapping the root id to null", () => {
     const onMove = jest.fn();
     const api = setupApi({ data: rowData, onMove });
-    // Simulate hovering the bottom drop zone: root parent, index past the end.
+    // The bottom drop zone hovers the root with an index past the end, just like
+    // computeDrop() reports it. tree.drop() should map the root id back to null.
     api.dispatch(dnd.dragStart("a", ["a"]));
-    api.dispatch(dnd.hovering(null, 3));
+    api.dispatch(dnd.hovering(api.root.id, 3));
     api.drop();
     expect(onMove).toHaveBeenCalledTimes(1);
     expect(onMove).toHaveBeenCalledWith(
@@ -33,11 +34,16 @@ describe("tree.drop() fires onMove (#313)", () => {
 
   test("coerces a null index (dropped onto a folder) to 0", () => {
     const onMove = jest.fn();
-    const api = setupApi({ data: rowData, onMove });
-    api.dispatch(dnd.dragStart("a", ["a"]));
-    api.dispatch(dnd.hovering(null, null));
+    const folderData = [{ id: "folder", children: [{ id: "child" }] }];
+    const api = setupApi({ data: folderData, onMove });
+    // Dropping onto a folder (rather than between rows) reports the folder as the
+    // parent with a null index, which tree.drop() should coerce to 0.
+    api.dispatch(dnd.dragStart("child", ["child"]));
+    api.dispatch(dnd.hovering("folder", null));
     api.drop();
-    expect(onMove).toHaveBeenCalledWith(expect.objectContaining({ index: 0 }));
+    expect(onMove).toHaveBeenCalledWith(
+      expect.objectContaining({ parentId: "folder", index: 0 }),
+    );
   });
 });
 

--- a/modules/react-arborist/src/interfaces/tree-api.ts
+++ b/modules/react-arborist/src/interfaces/tree-api.ts
@@ -546,6 +546,18 @@ export class TreeApi<T> {
     }
   }
 
+  drop() {
+    const { parentId, index, dragIds } = this.state.dnd;
+    safeRun(this.props.onMove, {
+      dragIds,
+      parentId: parentId === ROOT_ID ? null : parentId,
+      index: index === null ? 0 : index, // When it's null it was dropped over a folder
+      dragNodes: this.dragNodes,
+      parentNode: this.get(parentId),
+    });
+    this.open(parentId);
+  }
+
   hideCursor() {
     this.dispatch(dnd.cursor({ type: "none" }));
   }


### PR DESCRIPTION
## Summary

Fixes #313 — dragging a node to the empty area **below the last row** silently did nothing.

A previous refactor moved the `onMove`-firing drop logic out of the drag hook and into the per-row drop hook (`drop-hook.ts`), but it was never added to the **outer** (bottom-of-list) drop target (`outer-drop-hook.ts`). That target had `hover`/`canDrop` handlers — so it would show the drop cursor at the bottom — but no `drop` handler, so releasing there was ignored. Multiple users confirmed the regression on the issue.

### Changes

- Centralize the drop logic as a new `tree.drop()` method on `TreeApi` (reads the hovered `parentId`/`index` from dnd state and fires `onMove`).
- `drop-hook.ts` now delegates to `tree.drop()` instead of duplicating the logic inline.
- `outer-drop-hook.ts` gains the missing `drop` handler, guarded by the same `isOver({ shallow: true })` check already used in its `hover`/`canDrop`, so it only fires for genuine bottom-of-list drops and never double-fires when a nested row handles the drop.

## Test plan

- Added unit tests for `tree.drop()` (correct parent/index reporting; `null` index → `0` coercion).
- `yarn workspace react-arborist test` — 31 passing, warning-clean.
- `npx tsc --noEmit` clean.
- `yarn lint` clean. (`yarn fmt:check` flags a pre-existing `package.json` issue on `main`, untouched by this PR.)

## Checklist

- [x] Added a `.changes/` entry describing the change (see `.changes/README.md`).
- [x] `yarn lint` and `yarn workspace react-arborist test` pass (warning-clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)