### PR TITLE
Sync main package.json to 3.10.1 and guard against version drift

### DIFF
--- a/bin/release.mjs
+++ b/bin/release.mjs
@@ -60,6 +60,27 @@ function bump(current, kind) {
   fail(`Invalid version: "${kind}". Use patch, minor, major, or X.Y.Z.`);
 }
 
+/* Numeric semver compare: negative if a < b, positive if a > b, 0 if equal. */
+function compareVersions(a, b) {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) return pa[i] - pb[i];
+  }
+  return 0;
+}
+
+/* Highest X.Y.Z among existing vX.Y.Z tags, or null if there are none. */
+function latestReleasedVersion() {
+  const versions = out(`git tag -l "v[0-9]*"`)
+    .split("\n")
+    .filter(Boolean)
+    .map((t) => t.replace(/^v/, ""))
+    .filter((v) => /^\d+\.\d+\.\d+$/.test(v));
+  if (versions.length === 0) return null;
+  return versions.sort(compareVersions).at(-1);
+}
+
 /* Read every .changes/*.md (except README.md) and parse its frontmatter. Each
    file is a `--- key: value --- body` document; no YAML dep needed. */
 function readChangesets() {
@@ -156,6 +177,23 @@ if (changesets.length === 0) {
 
 const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
 const oldVersion = pkg.version;
+
+// Drift guard: a healthy release commit bumps package.json and creates its tag
+// together, so package.json should always match the highest existing release
+// tag. If a tag beyond package.json's version exists, a prior release's version
+// bump never landed on this branch (e.g. it was cut elsewhere and only the
+// changelog was back-ported). Continuing would recompute an already-published
+// version. Make package.json match the released version before releasing.
+const latestReleased = latestReleasedVersion();
+if (latestReleased && compareVersions(latestReleased, oldVersion) > 0) {
+  fail(
+    `package.json is at ${oldVersion}, but tag v${latestReleased} already exists — ` +
+      `this branch is behind the latest release. Bump ` +
+      `modules/react-arborist/package.json to ${latestReleased} (matching the ` +
+      `published version) and commit that before releasing.`,
+  );
+}
+
 // Derive the bump from the changeset types; an explicit arg overrides it.
 const maxRank = Math.max(...changesets.map((c) => TYPES[c.type].rank));
 const kind = versionArg ?? RANK_TO_BUMP[maxRank];

--- a/modules/react-arborist/package.json
+++ b/modules/react-arborist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-arborist",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "keywords": [
     "arborist",
     "dnd",


### PR DESCRIPTION
## Summary

`yarn release` on the current `main` fails with `Tag v3.10.1 already exists` — even though 3.10.1 shipped a while ago. Root cause: the 3.10.1 release was cut on a side branch that never merged back here. Its `package.json` bump and `v3.10.1` tag landed on that branch (and published to npm), but only the **changelog** was reproduced on `main` (#359). So `main`'s `package.json` was left at **3.10.0** while `v3.10.1` was already tagged and published. The release script derives the next version from `package.json` (3.10.0 → patch → 3.10.1) and collides with the existing tag.

This PR does two things:

1. **Sync `modules/react-arborist/package.json` to 3.10.1** — matching the version that's actually tagged and published. With this, `yarn release` correctly infers the next release as **3.10.2** from the pending `#313` changeset.
2. **Guard against this drift in `bin/release.mjs`** — a healthy release commit bumps `package.json` and creates its tag together, so `package.json` should always equal the highest existing release tag. If a tag *beyond* `package.json`'s version exists, the script now fails early with a clear message ("bump package.json to X.Y.Z … before releasing") instead of silently recomputing an already-published version.

## Test plan

- Guard logic against the repo's real tags: at the drifted `package.json=3.10.0` the guard **fires**; at the synced `3.10.1` it **passes**.
- End-to-end `node bin/release.mjs --preview --any-branch --no-tests` now reports **`Version: 3.10.1 → 3.10.2`** with no tag collision and the correctly assembled `#313` notes (previously errored on the collision).
- No `.changes/` entry: this touches `package.json` and `bin/`, not `modules/react-arborist/src/`, so it isn't a user-facing library change and the changeset gate doesn't apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)