### PR TITLE
Disable dragging a node while it's being renamed (#195)

### DIFF
--- a/.changes/195-no-drag-while-editing.md
+++ b/.changes/195-no-drag-while-editing.md
@@ -1,0 +1,8 @@
+---
+type: fix
+pr: 364
+---
+A node can no longer be dragged while it's being renamed (issue #195).
+Previously, dragging inside the rename input picked the row up and moved it —
+visible even in the official Gmail demo. The drag source now refuses to start a
+drag while the node is in editing state, matching the VS Code explorer.

--- a/modules/react-arborist/src/dnd/drag-hook.test.ts
+++ b/modules/react-arborist/src/dnd/drag-hook.test.ts
@@ -1,5 +1,5 @@
 import { NodeApi } from "../interfaces/node-api";
-import { dragTypeForNode } from "./drag-hook";
+import { canDragNode, dragTypeForNode } from "./drag-hook";
 
 /* dragTypeForNode only reads node.data when dragType is a function, so a
    minimal stub stands in for a real NodeApi. */
@@ -19,4 +19,22 @@ test("resolves a per-node dragType function against the node", () => {
   const dragType = (node: NodeApi<{ kind: string }>) => node.data.kind.toUpperCase();
   expect(dragTypeForNode(dragType, nodeWith({ kind: "folder" }))).toBe("FOLDER");
   expect(dragTypeForNode(dragType, nodeWith({ kind: "file" }))).toBe("FILE");
+});
+
+/* canDragNode only reads the isDraggable/isEditing flags, so a minimal stub
+   stands in for a real NodeApi. */
+function draggableNode(flags: { isDraggable: boolean; isEditing: boolean }): NodeApi {
+  return flags as NodeApi;
+}
+
+test("a draggable node that isn't being edited can drag", () => {
+  expect(canDragNode(draggableNode({ isDraggable: true, isEditing: false }))).toBe(true);
+});
+
+test("a non-draggable node can't drag", () => {
+  expect(canDragNode(draggableNode({ isDraggable: false, isEditing: false }))).toBe(false);
+});
+
+test("a node being renamed can't drag, even when draggable (#195)", () => {
+  expect(canDragNode(draggableNode({ isDraggable: true, isEditing: true }))).toBe(false);
 });

--- a/modules/react-arborist/src/dnd/drag-hook.ts
+++ b/modules/react-arborist/src/dnd/drag-hook.ts
@@ -15,12 +15,19 @@ export function dragTypeForNode<T>(dragType: TreeProps<T>["dragType"], node: Nod
   return dragType ?? "NODE";
 }
 
+/* A node can start a drag only when it's draggable and not currently being
+   renamed. Without the editing guard, dragging inside the rename input would
+   pick the row up and move it (issue #195). */
+export function canDragNode<T>(node: NodeApi<T>): boolean {
+  return node.isDraggable && !node.isEditing;
+}
+
 export function useDragHook<T>(node: NodeApi<T>): ConnectDragSource {
   const tree = useTreeApi<T>();
   const ids = tree.selectedIds;
   const [_, ref, preview] = useDrag<DragItem<T>, DropResult, void>(
     () => ({
-      canDrag: () => node.isDraggable,
+      canDrag: () => canDragNode(node),
       type: dragTypeForNode(tree.props.dragType, node),
       item: () => {
         // This is fired once at the beginning of a drag operation


### PR DESCRIPTION
## Summary

Fixes #195. A node stays draggable while its rename input is focused, so dragging *inside the input* picks the whole row up and moves it. This is visible even in the official [Gmail demo](https://react-arborist.netlify.app/gmail): start editing a node, then drag the input box and the node relocates.

The drag source gated `canDrag` only on `node.isDraggable`. This adds an editing guard so a row refuses to start a drag while it's in editing state, matching the VS Code explorer's behavior.

## Changes

- `dnd/drag-hook.ts`: extract a pure `canDragNode(node)` predicate (`node.isDraggable && !node.isEditing`) and use it for `canDrag`.
- `dnd/drag-hook.test.ts`: unit-test the predicate, including the editing case.
- `.changes/195-no-drag-while-editing.md`: changeset (`fix`).

## Test plan

- `yarn workspace react-arborist test` — 34 passing, warning-clean.
- Manually: in the Gmail demo, enter rename mode on a node and drag within the input — the row no longer moves; normal drag-to-reorder still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)