### PR TITLE
Scroll horizontally to reveal deeply nested nodes (#220)

### DIFF
--- a/.changes/367-scrollto-horizontal.md
+++ b/.changes/367-scrollto-horizontal.md
@@ -1,0 +1,8 @@
+---
+type: fix
+pr: 367
+---
+`scrollTo` (and the `selection` prop / `tree.scrollTo()` paths that use it) now
+scrolls horizontally as well as vertically, bringing a deeply nested node's
+indented content into view when rows overflow the tree's width. Previously only
+the vertical position was adjusted, leaving deep nodes off-screen to the right.

--- a/modules/react-arborist/src/interfaces/tree-api.test.ts
+++ b/modules/react-arborist/src/interfaces/tree-api.test.ts
@@ -213,6 +213,23 @@ describe("scrollTo brings a deeply nested node into view horizontally (#220)", (
     expect(el.scrollLeft).toBe(48);
   });
 
+  test("scrolls when the node's start sits exactly on the right edge", async () => {
+    // viewRight === left (48): the visible range is half-open, so the content
+    // start is already clipped and must be scrolled into view.
+    const el = { scrollWidth: 500, clientWidth: 48, scrollLeft: 0 };
+    const api = setupWithListEl(el);
+    await api.scrollTo("deep");
+    expect(el.scrollLeft).toBe(48);
+  });
+
+  test("clamps the target to the maximum scrollable distance", async () => {
+    // left (48) exceeds maxScroll (60 - 40 = 20), so scrollLeft is clamped.
+    const el = { scrollWidth: 60, clientWidth: 40, scrollLeft: 0 };
+    const api = setupWithListEl(el);
+    await api.scrollTo("deep");
+    expect(el.scrollLeft).toBe(20);
+  });
+
   test("leaves scroll untouched when the node is already in view", async () => {
     const el = { scrollWidth: 500, clientWidth: 200, scrollLeft: 0 };
     const api = setupWithListEl(el);

--- a/modules/react-arborist/src/interfaces/tree-api.test.ts
+++ b/modules/react-arborist/src/interfaces/tree-api.test.ts
@@ -184,3 +184,46 @@ describe("onSelect fires exactly once per selection method (#332)", () => {
     expect(onSelect).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("scrollTo brings a deeply nested node into view horizontally (#220)", () => {
+  // A folder tree where "deep" sits at level 2 (indented 2 * 24 = 48px).
+  const nestedData = [{ id: "root", children: [{ id: "mid", children: [{ id: "deep" }] }] }];
+
+  // react-window's scrollToItem only scrolls vertically; the horizontal scroll
+  // happens on the outer list element, which we stub here.
+  function setupWithListEl(el: Partial<HTMLDivElement>) {
+    const store = createStore(rootReducer);
+    const list = { current: { scrollToItem: jest.fn() } as any };
+    const listEl = { current: el as HTMLDivElement };
+    return new TreeApi(store, { data: nestedData }, list, listEl);
+  }
+
+  test("scrolls right when the node is past the right edge", async () => {
+    const el = { scrollWidth: 500, clientWidth: 40, scrollLeft: 0 };
+    const api = setupWithListEl(el);
+    await api.scrollTo("deep");
+    // Aligns the node's indentation start (level 2 * indent 24) to the left edge.
+    expect(el.scrollLeft).toBe(48);
+  });
+
+  test("scrolls left when the node is past the left edge", async () => {
+    const el = { scrollWidth: 500, clientWidth: 100, scrollLeft: 200 };
+    const api = setupWithListEl(el);
+    await api.scrollTo("deep");
+    expect(el.scrollLeft).toBe(48);
+  });
+
+  test("leaves scroll untouched when the node is already in view", async () => {
+    const el = { scrollWidth: 500, clientWidth: 200, scrollLeft: 0 };
+    const api = setupWithListEl(el);
+    await api.scrollTo("deep");
+    expect(el.scrollLeft).toBe(0);
+  });
+
+  test("no-ops when the list does not overflow horizontally", async () => {
+    const el = { scrollWidth: 100, clientWidth: 100, scrollLeft: 0 };
+    const api = setupWithListEl(el);
+    await api.scrollTo("deep");
+    expect(el.scrollLeft).toBe(0);
+  });
+});

--- a/modules/react-arborist/src/interfaces/tree-api.ts
+++ b/modules/react-arborist/src/interfaces/tree-api.ts
@@ -693,14 +693,17 @@ export class TreeApi<T> {
   private scrollToNodeHorizontally(node: NodeApi<T> | null) {
     const el = this.listEl.current;
     if (!node || !el) return;
-    if (el.scrollWidth <= el.clientWidth) return; // nothing to scroll
+    const maxScroll = el.scrollWidth - el.clientWidth;
+    if (maxScroll <= 0) return; // nothing to scroll
     const left = node.level * this.indent;
     const viewLeft = el.scrollLeft;
     const viewRight = el.scrollLeft + el.clientWidth;
-    /* Only move when the node's indentation is outside the viewport, then align
-       its content start to the left edge so the label is revealed. */
-    if (left < viewLeft || left > viewRight) {
-      el.scrollLeft = left;
+    /* The visible range is half-open [viewLeft, viewRight): a pixel at viewRight
+       is already clipped. Only move when the node's indentation falls outside
+       it, aligning its content start to the left edge so the label is revealed,
+       clamped to the list's scrollable range. */
+    if (left < viewLeft || left >= viewRight) {
+      el.scrollLeft = Math.max(0, Math.min(left, maxScroll));
     }
   }
 

--- a/modules/react-arborist/src/interfaces/tree-api.ts
+++ b/modules/react-arborist/src/interfaces/tree-api.ts
@@ -675,10 +675,33 @@ export class TreeApi<T> {
         const index = this.idToIndex[id];
         if (index === undefined) return;
         this.list.current?.scrollToItem(index, align);
+        /* react-window only scrolls vertically. A deeply nested node is
+           indented by level * indent and can sit past the right edge when rows
+           overflow horizontally, so bring it into view ourselves (#220). */
+        this.scrollToNodeHorizontally(this.get(id));
       })
       .catch(() => {
         // Id: ${id} never appeared in the list.
       });
+  }
+
+  /**
+   * Horizontally scroll the list so the node's indented content is in view.
+   * A no-op when the list doesn't overflow horizontally (the common case), so
+   * it never disturbs scrolling for trees that fit their width.
+   */
+  private scrollToNodeHorizontally(node: NodeApi<T> | null) {
+    const el = this.listEl.current;
+    if (!node || !el) return;
+    if (el.scrollWidth <= el.clientWidth) return; // nothing to scroll
+    const left = node.level * this.indent;
+    const viewLeft = el.scrollLeft;
+    const viewRight = el.scrollLeft + el.clientWidth;
+    /* Only move when the node's indentation is outside the viewport, then align
+       its content start to the left edge so the label is revealed. */
+    if (left < viewLeft || left > viewRight) {
+      el.scrollLeft = left;
+    }
   }
 
   /* State Checks */


### PR DESCRIPTION
## Summary

Fixes #220: `scrollTo` doesn't bring deeply nested nodes into view horizontally.

`scrollTo` only called react-window's `scrollToItem(index, align)`, which adjusts the **vertical** axis. A node is indented by `level * indent` (`row-container.tsx`), so when rows overflow the tree's width a deep node stays off-screen to the right — the tree scrolls down to its row but the label is never revealed. react-window doesn't know about react-arborist's horizontal indentation, so the library has to handle that axis itself.

## Change

After the vertical `scrollToItem`, `scrollTo` now nudges the list's outer element so the node's indentation start (`level * indent`) is within the horizontal viewport, aligning it to the left edge when it's off-screen in either direction.

- **No-op when there's no horizontal overflow** (`scrollWidth <= clientWidth`) — trees that fit their width are completely unaffected.
- Only moves when the node's indentation is actually outside the viewport (auto-style behavior), so it doesn't fight the user's scroll position unnecessarily.

## Test plan

- Added a `#220` block in `tree-api.test.ts` covering: scrolls right when past the right edge, scrolls left when past the left edge, no change when already in view, and no-op when the list doesn't overflow horizontally.
- `yarn test` — 53 passing.
- `tsc --noEmit` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)