### PR TITLE
Add scrollToOffset and scrollOffset to TreeApi (#194)

### DIFF
--- a/.changes/194-scroll-offset.md
+++ b/.changes/194-scroll-offset.md
@@ -1,0 +1,8 @@
+---
+type: feature
+pr: 368
+---
+`TreeApi` now exposes `scrollToOffset(offset)` to scroll the list to an exact
+pixel offset from the top, and a `scrollOffset` getter to read the current
+position — the offset-based counterpart to `scrollTo(id)`, useful for saving
+and restoring scroll position (#194).

--- a/README.md
+++ b/README.md
@@ -745,6 +745,14 @@ _tree_.**scrollTo**(_id_, _[align]_)
 
 Scroll to the node with _id_. If this node is not visible, this method will open all its parents. The align argument can be _"auto" | "smart" | "center" | "end" | "start"_.
 
+_tree_.**scrollToOffset**(_offset_)
+
+Scroll the list vertically to an exact pixel _offset_ from the top — the offset-based counterpart to _scrollTo_, useful for saving and restoring a scroll position. Negative or non-finite values are clamped to the top, and react-window clamps the upper bound to the scrollable range.
+
+_tree_.**scrollOffset** : _number_
+
+Returns the list's current vertical scroll offset, in pixels from the top. Pairs with _scrollToOffset_ to persist and restore the scroll position.
+
 ### Properties
 
 _tree_.**isEditing** : _boolean_

--- a/modules/react-arborist/src/interfaces/tree-api.test.ts
+++ b/modules/react-arborist/src/interfaces/tree-api.test.ts
@@ -267,6 +267,14 @@ describe("scrollToOffset / scrollOffset set and read the vertical position (#194
     expect(list.current.scrollTo).toHaveBeenCalledWith(0);
   });
 
+  test("scrollToOffset coerces non-finite offsets to the top", () => {
+    const { api, list } = setup();
+    api.scrollToOffset(NaN);
+    api.scrollToOffset(Infinity);
+    expect(list.current.scrollTo).toHaveBeenNthCalledWith(1, 0);
+    expect(list.current.scrollTo).toHaveBeenNthCalledWith(2, 0);
+  });
+
   test("scrollOffset reads the list element's scrollTop", () => {
     const { api } = setup({ scrollTop: 80 });
     expect(api.scrollOffset).toBe(80);

--- a/modules/react-arborist/src/interfaces/tree-api.test.ts
+++ b/modules/react-arborist/src/interfaces/tree-api.test.ts
@@ -244,3 +244,36 @@ describe("scrollTo brings a deeply nested node into view horizontally (#220)", (
     expect(el.scrollLeft).toBe(0);
   });
 });
+
+describe("scrollToOffset / scrollOffset set and read the vertical position (#194)", () => {
+  const data = [{ id: "a" }, { id: "b" }, { id: "c" }];
+
+  function setup(el?: Partial<HTMLDivElement>) {
+    const store = createStore(rootReducer);
+    const list = { current: { scrollTo: jest.fn() } as any };
+    const listEl = { current: (el ?? null) as HTMLDivElement | null };
+    return { api: new TreeApi(store, { data }, list, listEl), list, listEl };
+  }
+
+  test("scrollToOffset forwards the offset to the underlying list", () => {
+    const { api, list } = setup();
+    api.scrollToOffset(120);
+    expect(list.current.scrollTo).toHaveBeenCalledWith(120);
+  });
+
+  test("scrollToOffset clamps negative offsets to the top", () => {
+    const { api, list } = setup();
+    api.scrollToOffset(-50);
+    expect(list.current.scrollTo).toHaveBeenCalledWith(0);
+  });
+
+  test("scrollOffset reads the list element's scrollTop", () => {
+    const { api } = setup({ scrollTop: 80 });
+    expect(api.scrollOffset).toBe(80);
+  });
+
+  test("scrollOffset is 0 before the list element mounts", () => {
+    const { api } = setup();
+    expect(api.scrollOffset).toBe(0);
+  });
+});

--- a/modules/react-arborist/src/interfaces/tree-api.ts
+++ b/modules/react-arborist/src/interfaces/tree-api.ts
@@ -707,6 +707,21 @@ export class TreeApi<T> {
     }
   }
 
+  /**
+   * Scroll the list vertically to an exact pixel offset from the top. This is
+   * the offset-based counterpart to scrollTo(), handy for saving and restoring
+   * a scroll position (#194). Negative values are clamped to the top; react-
+   * window clamps the upper bound to the scrollable range.
+   */
+  scrollToOffset(offset: number) {
+    this.list.current?.scrollTo(Math.max(0, offset));
+  }
+
+  /** The list's current vertical scroll offset, in pixels from the top. */
+  get scrollOffset(): number {
+    return this.listEl.current?.scrollTop ?? 0;
+  }
+
   /* State Checks */
 
   get isEditing() {

--- a/modules/react-arborist/src/interfaces/tree-api.ts
+++ b/modules/react-arborist/src/interfaces/tree-api.ts
@@ -714,7 +714,10 @@ export class TreeApi<T> {
    * window clamps the upper bound to the scrollable range.
    */
   scrollToOffset(offset: number) {
-    this.list.current?.scrollTo(Math.max(0, offset));
+    /* Coerce non-finite offsets (NaN/Infinity, easy to get from malformed
+       persisted state) to the top rather than forwarding them to the list. */
+    const safe = Number.isFinite(offset) ? Math.max(0, offset) : 0;
+    this.list.current?.scrollTo(safe);
   }
 
   /** The list's current vertical scroll offset, in pixels from the top. */


### PR DESCRIPTION
## Summary

Adds an offset-based counterpart to `scrollTo(id)` so callers can save and restore the tree's scroll position without reaching into the DOM via `document.querySelector('[role="tree"]')` (the workaround in #194).

- `TreeApi.scrollToOffset(offset)` — scrolls the virtualized list to an exact pixel offset from the top (negative values clamp to the top; react-window clamps the upper bound).
- `TreeApi.scrollOffset` getter — reads the current vertical scroll offset in pixels.

Closes #194.

## Test plan

- Added unit tests in `tree-api.test.ts` covering: forwarding the offset to the list, clamping negatives, reading `scrollTop`, and the pre-mount default of `0`.
- `yarn jest` → 59/59 pass; `yarn tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)