### PR TITLE
Add disableDeselectOnClick prop (#245, #308)

### DIFF
--- a/.changes/245-disable-deselect-on-click.md
+++ b/.changes/245-disable-deselect-on-click.md
@@ -1,0 +1,7 @@
+---
+type: feature
+pr: 369
+---
+Added a `disableDeselectOnClick` prop. By default, clicking the empty area
+below the rows clears the selection; setting this prop keeps the current
+selection intact instead (#245, #308).

--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ interface TreeProps<T> {
   openByDefault?: boolean;
   selectionFollowsFocus?: boolean;
   disableMultiSelection?: boolean;
+  disableDeselectOnClick?: boolean;
   disableSelect?: string | boolean | BoolFunc<T>;
   disableEdit?: string | boolean | BoolFunc<T>;
   disableDrag?: string | boolean | BoolFunc<T>;

--- a/modules/react-arborist/src/components/default-container.test.tsx
+++ b/modules/react-arborist/src/components/default-container.test.tsx
@@ -1,5 +1,7 @@
+import { createRef } from "react";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { Tree } from "./tree";
+import { TreeApi } from "../interfaces/tree-api";
 
 type Datum = { id: string; name: string; children?: Datum[] };
 
@@ -90,4 +92,31 @@ test("marks the tree aria-multiselectable by default (#325)", () => {
 test("omits aria-multiselectable when multi-select is disabled (#325)", () => {
   render(<Tree<Datum> data={data} disableMultiSelection />);
   expect(screen.getByRole("tree").hasAttribute("aria-multiselectable")).toBe(false);
+});
+
+/* #245, #308: clicking the empty area below the rows clears the selection by
+   default; disableDeselectOnClick opts out of that. The deselect handler lives
+   on the list's outer (scroll) element, which is wired to tree.listEl. */
+test("clicking empty tree space clears the selection by default (#245)", async () => {
+  const ref = createRef<TreeApi<Datum> | undefined>();
+  render(<Tree<Datum> data={data} openByDefault ref={ref} />);
+  const [, a] = screen.getAllByRole("treeitem");
+
+  await click(a);
+  expect(a.getAttribute("aria-selected")).toBe("true");
+
+  await click(ref.current!.listEl.current!);
+  expect(a.getAttribute("aria-selected")).toBe("false");
+});
+
+test("disableDeselectOnClick keeps the selection when empty space is clicked (#245, #308)", async () => {
+  const ref = createRef<TreeApi<Datum> | undefined>();
+  render(<Tree<Datum> data={data} openByDefault disableDeselectOnClick ref={ref} />);
+  const [, a] = screen.getAllByRole("treeitem");
+
+  await click(a);
+  expect(a.getAttribute("aria-selected")).toBe("true");
+
+  await click(ref.current!.listEl.current!);
+  expect(a.getAttribute("aria-selected")).toBe("true");
 });

--- a/modules/react-arborist/src/components/list-outer-element.tsx
+++ b/modules/react-arborist/src/components/list-outer-element.tsx
@@ -14,6 +14,7 @@ export const ListOuterElement = forwardRef(function Outer(
       ref={ref}
       {...rest}
       onClick={(e) => {
+        if (tree.props.disableDeselectOnClick) return;
         if (e.currentTarget === e.target) tree.deselectAll();
       }}
     >

--- a/modules/react-arborist/src/types/tree-props.ts
+++ b/modules/react-arborist/src/types/tree-props.ts
@@ -44,6 +44,7 @@ export interface TreeProps<T> {
   openByDefault?: boolean;
   selectionFollowsFocus?: boolean;
   disableMultiSelection?: boolean;
+  disableDeselectOnClick?: boolean;
   disableSelect?: string | boolean | BoolFunc<T>;
   disableEdit?: string | boolean | BoolFunc<T>;
   disableDrag?: string | boolean | BoolFunc<T>;


### PR DESCRIPTION
## Summary

By default, clicking the empty area below the rows calls `tree.deselectAll()`, clearing the selection. Several users have asked to opt out of this (#245, #308) — e.g. when selection drives UI elsewhere in the app and shouldn't be lost on a stray click.

This adds a `disableDeselectOnClick` boolean prop (default `false`, so existing behavior is unchanged) that guards the single deselect handler in `ListOuterElement`.

```tsx
<Tree data={data} disableDeselectOnClick />
```

Note: the existing tree `onClick` prop can't substitute for this, because the deselect handler runs on the list's outer element *before* the click bubbles up to the `role="tree"` container — so the selection is already cleared by the time a user `onClick` fires.

Closes #245, closes #308.

## Test plan

- Added two tests in `default-container.test.tsx`: the default still deselects on empty-space click, and `disableDeselectOnClick` preserves the selection.
- `yarn jest` → 62/62 pass; `yarn tsc --noEmit` clean.
- README `TreeProps` interface and a changeset updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)