### PR TITLE
Rebuild the library before the showcase on deploy (#314)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,16 @@
+# Netlify build configuration for the react-arborist showcase (the demo site).
+#
+# The showcase resolves `react-arborist` through the monorepo workspace, which
+# is served from the library's built `dist/` output. That `dist/` is gitignored
+# (not committed), so every deploy must rebuild the library *before* building
+# the showcase. Otherwise the demo can be built against a stale, cached copy of
+# the library and ship an old version of react-arborist (#314).
+#
+# Versioning the build here (rather than only in the Netlify dashboard) keeps it
+# reviewable and guarantees the lib is rebuilt on every deploy. Note: for this
+# file to take effect, the site's "Base directory" in Netlify must be the repo
+# root (leave it blank) so Netlify reads this netlify.toml.
+
+[build]
+  command = "yarn build-lib && yarn workspace showcase build"
+  publish = "modules/showcase/out"


### PR DESCRIPTION
## Summary

Fixes the root cause behind #314 ("Demo website doesn't use the latest version of react-arborist").

The showcase (the hosted demo) depends on `react-arborist` via `workspace:*`, which is served from the library's **built `dist/`** output. That `dist/` is gitignored, so it isn't in the repo checkout — it only exists if the build produces it. If a deploy builds the showcase without rebuilding the library first (e.g. reusing a cached `dist/` from an earlier build), the demo ships against a **stale copy** of the library. That matches the report: the hosted demos lag behind the published version.

This PR adds a root `netlify.toml` that versions the build command so every deploy rebuilds the library before building the showcase:

```toml
[build]
  command = "yarn build-lib && yarn workspace showcase build"
  publish = "modules/showcase/out"
```

Keeping the build command in the repo (rather than only in the Netlify dashboard) makes it reviewable and guarantees the lib is rebuilt on each deploy.

## Test plan

Verified the pipeline locally from a clean tree (`dist/` absent):

- `yarn build-lib` → produces `modules/react-arborist/dist/{main,module}/index.js`
- `yarn workspace showcase build` → static export to `modules/showcase/out/` (index, cities, gmail, vscode, drag-out, variable-height, 404)

Both succeed and the showcase resolves the freshly built library.

## Note for the maintainer

For `netlify.toml` to take effect, the site's **Base directory** in the Netlify dashboard must be the repo root (left blank). If it's currently set to `modules/showcase`, Netlify won't read this file — clearing it (or moving the equivalent settings) will let this config apply. I don't have visibility into the dashboard, so worth a quick check before/after merge.