### PR TITLE
Add useSimpleTree onChange callback (#302)

### DIFF
--- a/.changes/302-simple-tree-onchange.md
+++ b/.changes/302-simple-tree-onchange.md
@@ -1,0 +1,7 @@
+---
+type: feature
+pr: 373
+---
+`useSimpleTree` now accepts an `onChange` option, called with the full data
+array after any internal move/create/rename/delete — a single place to persist
+the whole tree without wiring up each handler yourself.

--- a/modules/react-arborist/src/hooks/use-simple-tree.test.ts
+++ b/modules/react-arborist/src/hooks/use-simple-tree.test.ts
@@ -37,3 +37,63 @@ describe("useSimpleTree onCreate guards function accessors", () => {
     expect(() => act(() => void controller.onCreate({ ...create, type: "leaf" }))).not.toThrow();
   });
 });
+
+/* A single onChange callback lets callers persist the whole tree after any
+   internal mutation, without wiring up each handler themselves (#302). */
+describe("useSimpleTree onChange fires on mutations with the latest data (#302)", () => {
+  const initial = [
+    { id: "a", name: "a" },
+    { id: "b", name: "b" },
+  ];
+
+  function setup() {
+    const onChange = jest.fn();
+    const { result } = renderHook(() => useSimpleTree(initial, { onChange }));
+    return { onChange, data: () => result.current[0], controller: () => result.current[1] };
+  }
+
+  test("does not fire on mount", () => {
+    const { onChange } = setup();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test("fires on rename with the exact array the hook now returns", () => {
+    const { onChange, data, controller } = setup();
+    act(() => controller().onRename({ id: "a", name: "renamed", node: null as any }));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const arg = onChange.mock.calls[0][0];
+    expect(arg.find((n: any) => n.id === "a")?.name).toBe("renamed");
+    // onChange receives the same reference committed to state, not a fresh copy.
+    expect(data()).toBe(arg);
+  });
+
+  test("fires on move with the reordered data", () => {
+    const { onChange, controller } = setup();
+    act(() =>
+      controller().onMove({
+        dragIds: ["a"],
+        parentId: null,
+        index: 2,
+        dragNodes: [] as any,
+        parentNode: null,
+      }),
+    );
+    expect(onChange.mock.calls[0][0].map((n: any) => n.id)).toEqual(["b", "a"]);
+  });
+
+  test("fires on delete with the remaining data", () => {
+    const { onChange, controller } = setup();
+    act(() => controller().onDelete({ ids: ["a"], nodes: [] as any }));
+    expect(onChange.mock.calls[0][0].map((n: any) => n.id)).toEqual(["b"]);
+  });
+
+  test("fires on create with the grown data", () => {
+    const { onChange, controller } = setup();
+    act(
+      () =>
+        void controller().onCreate({ parentId: null, parentNode: null, index: 0, type: "leaf" }),
+    );
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toHaveLength(3);
+  });
+});

--- a/modules/react-arborist/src/hooks/use-simple-tree.ts
+++ b/modules/react-arborist/src/hooks/use-simple-tree.ts
@@ -13,7 +13,7 @@ export type UseSimpleTreeOptions<T> = SimpleTreeOptions<T> & {
      resulting data array — a single place to persist the whole tree without
      wiring up each handler yourself (#302). Fires only on real changes, not on
      mount or re-render. */
-  onChange?: (data: T[]) => void;
+  onChange?: (data: readonly T[]) => void;
 };
 
 let nextId = 0;

--- a/modules/react-arborist/src/hooks/use-simple-tree.ts
+++ b/modules/react-arborist/src/hooks/use-simple-tree.ts
@@ -8,16 +8,33 @@ export type SimpleTreeData = {
   children?: SimpleTreeData[];
 };
 
+export type UseSimpleTreeOptions<T> = SimpleTreeOptions<T> & {
+  /* Called after any internal mutation (move, create, rename, delete) with the
+     resulting data array — a single place to persist the whole tree without
+     wiring up each handler yourself (#302). Fires only on real changes, not on
+     mount or re-render. */
+  onChange?: (data: T[]) => void;
+};
+
 let nextId = 0;
 
-export function useSimpleTree<T>(initialData: readonly T[], options: SimpleTreeOptions<T> = {}) {
+export function useSimpleTree<T>(initialData: readonly T[], options: UseSimpleTreeOptions<T> = {}) {
   const [data, setData] = useState(initialData);
   const idAccessor = options.idAccessor;
   const childrenAccessor = options.childrenAccessor;
+  const onChange = options.onChange;
   const tree = useMemo(
     () => new SimpleTree<T>(data as T[], { idAccessor, childrenAccessor }),
     [data, idAccessor, childrenAccessor],
   );
+
+  /* Push the tree's new state into React and notify the caller. Reads
+     tree.data once so onChange receives exactly what was committed. */
+  const commit = () => {
+    const next = tree.data;
+    setData(next);
+    onChange?.(next);
+  };
 
   const onMove: MoveHandler<T> = (args: {
     dragIds: string[];
@@ -27,12 +44,12 @@ export function useSimpleTree<T>(initialData: readonly T[], options: SimpleTreeO
     for (const id of args.dragIds) {
       tree.move({ id, parentId: args.parentId, index: args.index });
     }
-    setData(tree.data);
+    commit();
   };
 
   const onRename: RenameHandler<T> = ({ name, id }) => {
     tree.update({ id, changes: { name } as any });
-    setData(tree.data);
+    commit();
   };
 
   // New nodes must carry their id/children under the same keys the accessors
@@ -57,13 +74,13 @@ export function useSimpleTree<T>(initialData: readonly T[], options: SimpleTreeO
     const data = { [idKey]: `simple-tree-id-${nextId++}`, name: "" } as any;
     if (type === "internal") data[childrenKey] = [];
     tree.create({ parentId, index, data });
-    setData(tree.data);
+    commit();
     return data;
   };
 
   const onDelete: DeleteHandler<T> = (args: { ids: string[] }) => {
     args.ids.forEach((id) => tree.drop({ id }));
-    setData(tree.data);
+    commit();
   };
 
   const controller = { onMove, onRename, onCreate, onDelete };


### PR DESCRIPTION
## Summary

Closes #302. Adds an `onChange` option to `useSimpleTree`, called with the full data array after any internal mutation (move / create / rename / delete):

```ts
const [data, controller] = useSimpleTree(initialData, {
  onChange: (data) => save(data), // persist the whole tree in one place
});
```

The requester stores the tree as a single JSON document and wanted one callback to react to all changes rather than implementing every handler. `useSimpleTree` already funnels every mutation through a `setData(tree.data)`, so this adds a tiny `commit()` helper that both updates state and notifies the caller.

Notes:
- Fires **only on real mutations**, not on mount or re-render — more precise than a `useEffect(() => save(data), [data])`, which also runs on initial mount.
- `onChange` receives the exact array committed to state (same reference the hook then returns), so callers can compare/store it directly.
- No changes to the core `Tree` or the `SimpleTree` class; purely additive and backward-compatible.

## Test plan

- `yarn test` (full suite): 69 passing (was 64; +5 new).
- New `#302` tests cover: does-not-fire-on-mount, and fires with the correct data on rename / move / delete / create.
- `yarn lint` and `yarn fmt:check` clean; `tsc --noEmit` passes.
- Includes a `feature` changeset (minor bump).