### PR TITLE
Bind NodeApi action methods so they can be passed as callbacks (#301)

### DIFF
--- a/.changes/301-bind-node-methods.md
+++ b/.changes/301-bind-node-methods.md
@@ -1,0 +1,8 @@
+---
+type: fix
+pr: 374
+---
+`NodeApi` action methods (`toggle`, `select`, `activate`, `focus`, `edit`, etc.)
+are now bound to the node, so passing them as callbacks — e.g.
+`<Toggle onClick={node.toggle} />` — no longer throws "Cannot read properties of
+undefined (reading 'tree')" when invoked detached.

--- a/modules/react-arborist/src/interfaces/node-api.test.ts
+++ b/modules/react-arborist/src/interfaces/node-api.test.ts
@@ -1,0 +1,63 @@
+import { createStore } from "redux";
+import { rootReducer } from "../state/root-reducer";
+import { TreeProps } from "../types/tree-props";
+import { TreeApi } from "./tree-api";
+
+function setupApi(props: TreeProps<any>) {
+  const store = createStore(rootReducer);
+  return new TreeApi(store, props, { current: null }, { current: null });
+}
+
+const data = [{ id: "folder", children: [{ id: "child" }] }, { id: "leaf" }];
+
+/* NodeApi's action methods must survive being passed as bare callbacks — e.g.
+   `<Toggle onClick={node.toggle} />` — without losing `this`. Before they were
+   bound in the constructor, a detached call read `this.tree` off `undefined`
+   and threw "Cannot read properties of undefined (reading 'tree')" (#301). */
+describe("NodeApi action methods are bound to the instance (#301)", () => {
+  test("a detached node.toggle still toggles the node's open state", () => {
+    const api = setupApi({ data });
+    const node = api.get("folder")!;
+    expect(node.isOpen).toBe(true); // openByDefault
+    const { toggle } = node; // detach, as a custom renderer passing node.toggle would
+    expect(() => toggle()).not.toThrow();
+    expect(api.isOpen("folder")).toBe(false);
+    toggle();
+    expect(api.isOpen("folder")).toBe(true);
+  });
+
+  test("a detached node.select still selects the node", () => {
+    const onSelect = jest.fn();
+    const api = setupApi({ data, onSelect });
+    const { select } = api.get("leaf")!;
+    expect(() => select()).not.toThrow();
+    expect(api.selectedIds.has("leaf")).toBe(true);
+  });
+
+  test.each([
+    "select",
+    "deselect",
+    "selectMulti",
+    "selectContiguous",
+    "activate",
+    "focus",
+    "toggle",
+    "open",
+    "openParents",
+    "close",
+    "reset",
+    "edit",
+  ] as const)("node.%s is bound and callable while detached", (method) => {
+    const api = setupApi({ data });
+    const node = api.get("folder")!;
+    const fn = node[method] as () => unknown;
+    // The own, bound copy is a different reference than the prototype method.
+    expect(node[method]).not.toBe(NodeApi_proto(node)[method]);
+    expect(() => fn()).not.toThrow();
+  });
+});
+
+// Reach the prototype to prove the bound method is an own property shadowing it.
+function NodeApi_proto(node: object): any {
+  return Object.getPrototypeOf(node);
+}

--- a/modules/react-arborist/src/interfaces/node-api.test.ts
+++ b/modules/react-arborist/src/interfaces/node-api.test.ts
@@ -34,6 +34,14 @@ describe("NodeApi action methods are bound to the instance (#301)", () => {
     expect(api.selectedIds.has("leaf")).toBe(true);
   });
 
+  test("a detached node.submit still submits a rename (takes an argument)", () => {
+    const onRename = jest.fn();
+    const api = setupApi({ data, onRename });
+    const { submit } = api.get("leaf")!;
+    expect(() => submit("renamed")).not.toThrow();
+    expect(onRename).toHaveBeenCalledWith(expect.objectContaining({ id: "leaf", name: "renamed" }));
+  });
+
   test.each([
     "select",
     "deselect",
@@ -46,6 +54,7 @@ describe("NodeApi action methods are bound to the instance (#301)", () => {
     "openParents",
     "close",
     "reset",
+    "submit",
     "edit",
   ] as const)("node.%s is bound and callable while detached", (method) => {
     const api = setupApi({ data });

--- a/modules/react-arborist/src/interfaces/node-api.ts
+++ b/modules/react-arborist/src/interfaces/node-api.ts
@@ -32,6 +32,24 @@ export class NodeApi<T = any> {
     this.parent = params.parent;
     this.isDraggable = params.isDraggable;
     this.rowIndex = params.rowIndex;
+
+    /* Bind the action methods to the instance so they can be passed as
+       callbacks (e.g. `<Toggle onClick={node.toggle} />`) without losing `this`.
+       A detached call would otherwise read `this.tree` off `undefined` and throw
+       "Cannot read properties of undefined (reading 'tree')" (#301). */
+    this.select = this.select.bind(this);
+    this.deselect = this.deselect.bind(this);
+    this.selectMulti = this.selectMulti.bind(this);
+    this.selectContiguous = this.selectContiguous.bind(this);
+    this.activate = this.activate.bind(this);
+    this.focus = this.focus.bind(this);
+    this.toggle = this.toggle.bind(this);
+    this.open = this.open.bind(this);
+    this.openParents = this.openParents.bind(this);
+    this.close = this.close.bind(this);
+    this.submit = this.submit.bind(this);
+    this.reset = this.reset.bind(this);
+    this.edit = this.edit.bind(this);
   }
 
   get isRoot() {


### PR DESCRIPTION
## Summary

Fixes the crash reported in #301 (rolled up under #348): `Cannot read properties of undefined (reading 'tree')` when performing an action on a node.

**Root cause.** `NodeApi`'s action methods (`toggle`, `select`, `deselect`, `selectMulti`, `selectContiguous`, `activate`, `focus`, `open`, `openParents`, `close`, `submit`, `reset`, `edit`) were plain prototype methods. A custom node renderer naturally passes one as a bare callback — e.g. `<Toggle onClick={node.toggle} />` — which detaches it from its instance. When later invoked, `this` is `undefined`, so `this.tree` throws. The default row avoids this only because `handleClick` is a bound arrow field; the other methods weren't bound.

**Fix.** Bind the action methods to the instance in the constructor, matching the already-bound `handleClick`. Fully backward-compatible — `node.toggle()` etc. still work exactly as before.

## Verification

I built a Tanstack-Start-shaped reproduction (React 19 + Vite **SSR + hydration**) driven headlessly with Playwright:
- **Before the fix:** clicking a custom toggle wired as `node.toggle` throws `TypeError: Cannot read properties of undefined (reading 'tree') at toggle` — exactly #301.
- **After the fix (local build swapped in):** identical interaction runs clean, no page errors.

(For completeness, the minifier reports rolled up in #348 — #155/#165 — are a separate, external SWC minifier bug fixed in Next ≥ 13.4.14, not addressed here.)

## Test plan

- New `node-api.test.ts` (#301): detached `node.toggle`/`node.select` still work, and every bound action method is callable while detached.
- `yarn test` full suite: 83 passing (was 69; +14). No regressions in `clone()`, which spreads `this`.
- `tsc --noEmit`, `yarn lint`, `yarn fmt:check` all clean.
- Includes a `fix` changeset (patch bump).