### PR TITLE
Remove the .id-assuming free identify(); keep the selection slice string-only

### DIFF
--- a/modules/react-arborist/src/interfaces/tree-api.test.ts
+++ b/modules/react-arborist/src/interfaces/tree-api.test.ts
@@ -87,6 +87,19 @@ describe("custom idAccessor is honored when methods receive raw data (#347)", ()
     api.select(fnData[1]);
     expect(api.selectedIds.has("y")).toBe(true);
   });
+
+  test("selectContiguous resolves nodes to accessor-derived ids", () => {
+    // selectContiguous feeds NodeApi lists to the selection slice, which stores
+    // ids. Those must be the accessor-derived ids, not `undefined` from a missing
+    // `.id` — guards the string-only selection slice against a custom accessor.
+    const api = setupApi({
+      data: [{ uuid: "a" }, { uuid: "b" }, { uuid: "c" }, { uuid: "d" }],
+      idAccessor: "uuid",
+    });
+    api.select("a");
+    api.selectContiguous("c");
+    expect([...api.selectedIds].sort()).toEqual(["a", "b", "c"]);
+  });
 });
 
 describe("custom idAccessor flows through drag-and-drop onMove (#170)", () => {

--- a/modules/react-arborist/src/interfaces/tree-api.ts
+++ b/modules/react-arborist/src/interfaces/tree-api.ts
@@ -468,8 +468,8 @@ export class TreeApi<T> {
       const selectableNodes = this.filterSelectableNodes(
         this.nodesBetween(anchor, this.identifyNull(id)),
       );
-      this.dispatch(selection.remove(this.nodesBetween(anchor, mostRecent)));
-      this.dispatch(selection.add(selectableNodes));
+      this.dispatch(selection.remove(this.nodesBetween(anchor, mostRecent).map((n) => n.id)));
+      this.dispatch(selection.add(selectableNodes.map((n) => n.id)));
       this.dispatch(selection.mostRecent(id));
     }
     this.scrollTo(id);

--- a/modules/react-arborist/src/state/selection-slice.ts
+++ b/modules/react-arborist/src/state/selection-slice.ts
@@ -1,5 +1,4 @@
-import { ActionTypes, IdObj } from "../types/utils";
-import { identify } from "../utils";
+import { ActionTypes } from "../types/utils";
 import { initialState } from "./initial";
 
 /* Types */
@@ -9,23 +8,26 @@ export type SelectionState = {
   mostRecent: string | null;
 };
 
-/* Actions */
+/* Actions. These take ids already resolved to strings: callers go through
+   TreeApi.identify(), which honors a custom idAccessor. Keeping the slice
+   string-only means there is a single, accessor-aware identify() rather than a
+   second `.id`-assuming one hiding here. */
 export const actions = {
   clear: () => ({ type: "SELECTION_CLEAR" as const }),
 
-  only: (id: string | IdObj) => ({
+  only: (id: string) => ({
     type: "SELECTION_ONLY" as const,
-    id: identify(id),
+    id,
   }),
 
-  add: (id: string | string[] | IdObj | IdObj[]) => ({
+  add: (id: string | string[]) => ({
     type: "SELECTION_ADD" as const,
-    ids: (Array.isArray(id) ? id : [id]).map(identify),
+    ids: Array.isArray(id) ? id : [id],
   }),
 
-  remove: (id: string | string[] | IdObj | IdObj[]) => ({
+  remove: (id: string | string[]) => ({
     type: "SELECTION_REMOVE" as const,
-    ids: (Array.isArray(id) ? id : [id]).map(identify),
+    ids: Array.isArray(id) ? id : [id],
   }),
 
   set: (args: { ids: Set<string>; anchor: string | null; mostRecent: string | null }) => ({
@@ -33,14 +35,14 @@ export const actions = {
     ...args,
   }),
 
-  mostRecent: (id: string | null | IdObj) => ({
+  mostRecent: (id: string | null) => ({
     type: "SELECTION_MOST_RECENT" as const,
-    id: id === null ? null : identify(id),
+    id,
   }),
 
-  anchor: (id: string | null | IdObj) => ({
+  anchor: (id: string | null) => ({
     type: "SELECTION_ANCHOR" as const,
-    id: id === null ? null : identify(id),
+    id,
   }),
 };
 

--- a/modules/react-arborist/src/utils.ts
+++ b/modules/react-arborist/src/utils.ts
@@ -1,6 +1,5 @@
 import { NodeApi } from "./interfaces/node-api";
 import { TreeApi } from "./interfaces/tree-api";
-import { IdObj } from "./types/utils";
 
 export function bound(n: number, min: number, max: number) {
   return Math.max(Math.min(n, max), min);
@@ -116,15 +115,6 @@ export function access<T = boolean>(obj: any, accessor: string | boolean | Funct
   if (typeof accessor === "boolean") return accessor as unknown as T;
   if (typeof accessor === "string") return obj[accessor] as T;
   return accessor(obj) as T;
-}
-
-export function identifyNull(obj: string | IdObj | null) {
-  if (obj === null) return null;
-  else return identify(obj);
-}
-
-export function identify(obj: string | IdObj) {
-  return typeof obj === "string" ? obj : obj.id;
 }
 
 export function mergeRefs(...refs: any) {


### PR DESCRIPTION
## Summary

Internal cleanup — removes a latent footgun surfaced while closing #347.

`state/selection-slice.ts` accepted `string | IdObj` and resolved ids through a **free `utils.identify()`** that reads `.id` directly. That was a second, **accessor-unaware** `identify()` living next to the real, accessor-aware `TreeApi.identify()`. It happened to be safe only because every caller pre-resolves ids before dispatching — but it's exactly the kind of `.id`-assuming code that silently breaks a custom `idAccessor`.

Changes:
- Selection action creators (`only`/`add`/`remove`/`mostRecent`/`anchor`) now take **already-resolved string ids** only. The slice no longer imports `identify`/`IdObj`.
- The two spots in `selectContiguous` that passed `NodeApi[]` now map to `.id` at the call site (those ids are accessor-derived at node construction).
- Deleted the now-unused free `identify()`/`identifyNull()` from `utils.ts`, leaving `TreeApi.identify()` as the single source of truth.

No public API or behavior change — the action creators are internal to `TreeApi`.

## Test plan

- New test: `selectContiguous` selects the correct range under a custom `idAccessor: "uuid"` (guards the refactored NodeApi→id mapping).
- `yarn test` full suite: 86 passing. No regressions in the existing selection / `#332` onSelect tests.
- `tsc --noEmit`, `yarn lint`, `yarn fmt:check` all clean.

Test-only + internal refactor, so no changelog entry — please apply `skip-changelog`.