### PR TITLE
Allow dropping as a sibling between an open folder and its first child (#330)

### DIFF
--- a/.changes/330-drop-sibling-open-folder.md
+++ b/.changes/330-drop-sibling-open-folder.md
@@ -1,0 +1,9 @@
+---
+type: feature
+---
+Dragging into the gap between an open folder and its first child now supports a
+horizontal slide, matching how items and closed folders already behave. Sliding
+right still drops the node as the folder's first child (the previous behavior);
+sliding left drops it as a sibling — or grandsibling — of the folder, bounded by
+the folder's ancestor chain. `computeDrop` previously hard-coded this gap to
+"first child," so the level was pinned and the slide never engaged (issue #330).

--- a/.changes/330-drop-sibling-open-folder.md
+++ b/.changes/330-drop-sibling-open-folder.md
@@ -1,5 +1,6 @@
 ---
 type: feature
+pr: 378
 ---
 Dragging into the gap between an open folder and its first child now supports a
 horizontal slide, matching how items and closed folders already behave. Sliding

--- a/modules/react-arborist/src/dnd/compute-drop.test.ts
+++ b/modules/react-arborist/src/dnd/compute-drop.test.ts
@@ -1,0 +1,136 @@
+import { createStore } from "redux";
+import { rootReducer } from "../state/root-reducer";
+import { ROOT_ID } from "../data/create-root";
+import { TreeProps } from "../types/tree-props";
+import { TreeApi } from "../interfaces/tree-api";
+import { computeDrop } from "./compute-drop";
+
+const ROW = 40; // height; top edge at y<10, middle 10..30, bottom edge y>30
+const INDENT = 24;
+
+function setupApi(props: TreeProps<any>) {
+  const store = createStore(rootReducer);
+  return new TreeApi(
+    store,
+    { indent: INDENT, rowHeight: ROW, ...props },
+    { current: null },
+    {
+      current: null,
+    },
+  );
+}
+
+/*
+ * Drive computeDrop against a hovered row. The row's rect is pinned at the
+ * origin so `offset` doubles as the in-row coordinate:
+ *   - y picks the vertical band (5 = top edge, 20 = middle, 35 = bottom edge)
+ *   - x picks the horizontal drop level; hoverLevel = round((x - indent)/indent),
+ *     so x = (level + 1) * indent targets `level`, and a large x slides fully right.
+ */
+function hover(api: TreeApi<any>, id: string, x: number, y: number) {
+  const node = api.get(id)!;
+  const element = {
+    getBoundingClientRect: () => ({ x: 0, y: 0, height: ROW }),
+  } as unknown as HTMLElement;
+  return computeDrop({
+    element,
+    offset: { x, y },
+    indent: api.indent,
+    node,
+    prevNode: node.prev,
+    nextNode: node.next,
+  });
+}
+
+const AT_TOP = 5;
+const MIDDLE = 20;
+const AT_BOTTOM = 35;
+const DEEP = 1000; // slides fully right
+const levelX = (level: number) => (level + 1) * INDENT;
+
+/*
+ * Visible tree (all folders open by default):
+ *   a                 item,          level 0, root index 0
+ *   F                 open folder,   level 0, root index 1
+ *     G               open folder,   level 1, F index 0
+ *       C             item,          level 2, G index 0
+ *   E                 empty folder,  level 0, root index 2
+ *   z                 item,          level 0, root index 3
+ */
+const data = [
+  { id: "a" },
+  { id: "F", children: [{ id: "G", children: [{ id: "C" }] }] },
+  { id: "E", children: [] },
+  { id: "z" },
+];
+
+describe("computeDrop", () => {
+  describe("existing branches (regression net)", () => {
+    test("middle of a folder drops into it and highlights the row", () => {
+      const api = setupApi({ data });
+      const { drop, cursor } = hover(api, "F", levelX(0), MIDDLE);
+      expect(drop).toEqual({ parentId: "F", index: null });
+      expect(cursor).toEqual({ type: "highlight", id: "F" });
+    });
+
+    test("top of the first row drops at the top of the root", () => {
+      const api = setupApi({ data });
+      const { drop, cursor } = hover(api, "a", levelX(0), AT_TOP);
+      expect(drop).toEqual({ parentId: ROOT_ID, index: 0 });
+      expect(cursor).toEqual({ type: "line", index: 0, level: 0 });
+    });
+
+    test("below an item, sliding left walks up the ancestor chain", () => {
+      const api = setupApi({ data });
+      // Below C (level 2); its next row z is level 0, so the slide spans 0..2.
+      const deep = hover(api, "C", DEEP, AT_BOTTOM);
+      expect(deep.drop).toEqual({ parentId: "G", index: 1 }); // next sibling of C
+      const shallow = hover(api, "C", levelX(0), AT_BOTTOM);
+      expect(shallow.drop).toEqual({ parentId: ROOT_ID, index: 2 }); // after F, at root
+    });
+
+    test("below a closed folder behaves like an item", () => {
+      const api = setupApi({ data });
+      api.close("F", false); // rebuild the visible list so F's next row is E
+      api.update(api.props);
+      // With F closed, its next row is E (level 0). Sliding right pins to F's level.
+      const deep = hover(api, "F", DEEP, AT_BOTTOM);
+      expect(deep.drop).toEqual({ parentId: ROOT_ID, index: 2 }); // sibling after F
+    });
+
+    test("empty open folder: deep drops inside, shallow drops as a sibling", () => {
+      const api = setupApi({ data });
+      const deep = hover(api, "E", DEEP, AT_BOTTOM);
+      expect(deep.drop).toEqual({ parentId: "E", index: 0 }); // first child of E
+      const shallow = hover(api, "E", levelX(0), AT_BOTTOM);
+      expect(shallow.drop).toEqual({ parentId: ROOT_ID, index: 3 }); // sibling after E
+    });
+  });
+
+  describe("open folder with children (#330)", () => {
+    test("sliding right still drops as the folder's first child", () => {
+      const api = setupApi({ data });
+      const { drop, cursor } = hover(api, "F", DEEP, AT_BOTTOM);
+      expect(drop).toEqual({ parentId: "F", index: 0 });
+      expect(cursor).toEqual({ type: "line", index: 2, level: 1 });
+    });
+
+    test("sliding left drops as the folder's next sibling", () => {
+      const api = setupApi({ data });
+      const { drop, cursor } = hover(api, "F", levelX(0), AT_BOTTOM);
+      expect(drop).toEqual({ parentId: ROOT_ID, index: 2 }); // after F, at root
+      expect(cursor).toEqual({ type: "line", index: 2, level: 0 });
+    });
+
+    test("a nested folder can drop as sibling or grandsibling, bounded by its ancestors", () => {
+      const api = setupApi({ data });
+      // Between G (level 1) and its child C (level 2).
+      const child = hover(api, "G", DEEP, AT_BOTTOM);
+      expect(child.drop).toEqual({ parentId: "G", index: 0 }); // first child of G
+      const sibling = hover(api, "G", levelX(1), AT_BOTTOM);
+      expect(sibling.drop).toEqual({ parentId: "F", index: 1 }); // after G, inside F
+      const grandsibling = hover(api, "G", levelX(0), AT_BOTTOM);
+      expect(grandsibling.drop).toEqual({ parentId: ROOT_ID, index: 2 }); // after F, at root
+    });
+  });
+});

--- a/modules/react-arborist/src/dnd/compute-drop.ts
+++ b/modules/react-arborist/src/dnd/compute-drop.ts
@@ -1,6 +1,6 @@
 import { XYCoord } from "react-dnd";
 import { NodeApi } from "../interfaces/node-api";
-import { bound, indexOf, isClosed, isItem, isOpenWithEmptyChildren } from "../utils";
+import { bound, indexOf, isClosed, isItem } from "../utils";
 import { DropResult } from "./drop-hook";
 
 function measureHover(el: HTMLElement, offset: XYCoord) {
@@ -150,27 +150,27 @@ export function computeDrop(args: Args): ComputedDrop {
     };
   }
 
-  /* The node above the cursor line is an open folder with no children */
-  if (isOpenWithEmptyChildren(above)) {
-    const level = bound(hoverLevel, 0, above.level + 1);
-    if (level > above.level) {
-      /* Will be the first child of the empty folder */
-      return {
-        drop: dropAt(above.id, 0),
-        cursor: lineCursor(above.rowIndex! + 1, level),
-      };
-    } else {
-      /* Will be a sibling or grandsibling of the empty folder */
-      return {
-        drop: walkUpFrom(above, level),
-        cursor: lineCursor(above.rowIndex! + 1, level),
-      };
-    }
+  /*
+   * The node above the cursor is an open folder — empty or with children.
+   * `below` is either the folder's first child (children) or its next sibling
+   * (empty), but neither pins the slide: the deep end is the folder's first
+   * child (above.level + 1) and the shallow end walks up the ancestor chain,
+   * which walkUpFrom() clamps at the root. Sliding right drops as the first
+   * child (the historical default); sliding left drops as a sibling or
+   * grandsibling of the folder (#330).
+   */
+  const level = bound(hoverLevel, 0, above.level + 1);
+  if (level > above.level) {
+    /* Will be the first child of the folder */
+    return {
+      drop: dropAt(above.id, 0),
+      cursor: lineCursor(above.rowIndex! + 1, level),
+    };
+  } else {
+    /* Will be a sibling or grandsibling of the folder */
+    return {
+      drop: walkUpFrom(above, level),
+      cursor: lineCursor(above.rowIndex! + 1, level),
+    };
   }
-
-  /* The node above the cursor is a an open folder with children */
-  return {
-    drop: dropAt(above?.id, 0),
-    cursor: lineCursor(above.rowIndex! + 1, above.level + 1),
-  };
 }


### PR DESCRIPTION
## Summary

Closes #330.

Dragging into the gap between an open folder and its first child was locked to a single drop target — "first child of the folder." You couldn't slide the cursor left to drop the node as a *sibling* of the folder, even though items, closed folders, and empty open folders all support that horizontal slide.

The cause was in `computeDrop` (`compute-drop.ts`): the final branch — open folder *with* children — hard-coded the result:

```ts
return {
  drop: dropAt(above?.id, 0),                        // always first child
  cursor: lineCursor(above.rowIndex! + 1, above.level + 1),  // level pinned
};
```

`hoverLevel` was computed but never consulted, so the slide never engaged. Every other branch derives its level from `bound(hoverLevel, …)`.

This PR unifies the open-folder handling (empty and non-empty become identical, so the two branches merge into one):

- Sliding **right** → drop as the folder's first child — the previous default, preserved.
- Sliding **left** → drop as a sibling or grandsibling of the folder, clamped to the folder's ancestor chain by `walkUpFrom()`.

The lower bound is `0` rather than `below.level`, because here `below` is the folder's first child (at `folder.level + 1`) and would otherwise re-pin the slide; `walkUpFrom()` already clamps the shallow end to real ancestors.

## Test plan

`compute-drop.ts` had no unit tests despite being flagged in-source as "the most complex, tricky function in the whole repo." This adds `compute-drop.test.ts`, which drives `computeDrop` through real `TreeApi`/`NodeApi` fixtures (no DOM needed) and covers:

- Existing branches as a regression net: drop-into-folder (middle), top-of-list, item slide across ancestor levels, closed folder, empty open folder.
- The #330 behavior: first-child on right-slide (default preserved), next-sibling on left-slide, and sibling/grandsibling for a nested folder bounded by its ancestor chain.

- [x] `yarn lint` — 0 warnings, 0 errors
- [x] `yarn fmt:check` — clean (for the files this PR touches)
- [x] `yarn workspace react-arborist test` — 106 passed
- [x] `tsc --noEmit` — clean

## Checklist

- [x] Added a `.changes/` entry (`.changes/330-drop-sibling-open-folder.md`).
- [x] `yarn lint`, `yarn fmt:check`, and `yarn workspace react-arborist test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)