### PR TITLE
Add adjustMoveIndex helper for custom onMove handlers (#247)

### DIFF
--- a/.changes/247-adjust-move-index.md
+++ b/.changes/247-adjust-move-index.md
@@ -1,0 +1,10 @@
+---
+type: feature
+---
+Added an `adjustMoveIndex` helper for custom `onMove` handlers. `onMove`'s
+`index` is a pre-removal slot (it counts the destination rows as displayed,
+with the dragged rows still in place), which trips up handlers that splice the
+dragged rows out before inserting them — dragging a row just below itself would
+jump it past its neighbor. `adjustMoveIndex({ index, dragIds, siblingIds })`
+returns the index to insert at after removal. `SimpleTree`/`useSimpleTree` are
+unaffected; they already insert before removing (issue #247).

--- a/README.md
+++ b/README.md
@@ -142,6 +142,26 @@ function App() {
 }
 ```
 
+#### The `onMove` index
+
+`onMove`'s `index` is a **pre-removal slot**: it counts positions in the destination parent's child list _as shown on screen_, with the dragged rows still in place. If your handler removes the dragged rows before inserting them — the natural way to reorder an array — every dragged row that started before the drop slot shifts your target one place to the left, so dragging a row to just below itself would jump it past its neighbor (issue [#247](https://github.com/jameskerr/react-arborist/issues/247)).
+
+`SimpleTree` / `useSimpleTree` insert before removing, so they need no adjustment. If you manage the data yourself, use the exported `adjustMoveIndex` helper:
+
+```jsx
+import { adjustMoveIndex } from "react-arborist";
+
+const onMove = ({ dragIds, index }) => {
+  const to = adjustMoveIndex({ index, dragIds, siblingIds: data.map((d) => d.id) });
+  const dragged = data.filter((d) => dragIds.includes(d.id));
+  const rest = data.filter((d) => !dragIds.includes(d.id));
+  rest.splice(to, 0, ...dragged);
+  setData(rest);
+};
+```
+
+Pass the destination parent's current child ids in display order (for a root-level move, that's your top-level data's ids). Ids that aren't among them — rows moving in from another parent — don't shift anything.
+
 ### Tree Filtering
 
 Providing a non-empty _searchTerm_ will only show nodes that match. If a child matches, all its parents also match. Internal nodes are opened when filtering. You can provide your own _searchMatch_ function, or use the default.

--- a/modules/react-arborist/src/data/adjust-move-index.test.ts
+++ b/modules/react-arborist/src/data/adjust-move-index.test.ts
@@ -1,0 +1,73 @@
+import { adjustMoveIndex } from "./adjust-move-index";
+
+/* Apply an onMove the naive remove-then-insert way, using the adjusted index,
+   and return the resulting id order. Mirrors what a custom onMove does with a
+   flat data array. */
+function reorder(ids: string[], dragIds: string[], index: number): string[] {
+  const to = adjustMoveIndex({ index, dragIds, siblingIds: ids });
+  const dragged = ids.filter((id) => dragIds.includes(id));
+  const rest = ids.filter((id) => !dragIds.includes(id));
+  rest.splice(to, 0, ...dragged);
+  return rest;
+}
+
+describe("adjustMoveIndex (#247)", () => {
+  const list = ["a", "b", "c"];
+
+  test("dropping a row just below itself keeps it in place", () => {
+    // computeDrop reports index 1 for the a|b gap; the raw value would move "a"
+    // past "b". Adjusting brings it back to 0.
+    expect(adjustMoveIndex({ index: 1, dragIds: ["a"], siblingIds: list })).toBe(0);
+    expect(reorder(list, ["a"], 1)).toEqual(["a", "b", "c"]);
+  });
+
+  test("dropping a row just above itself keeps it in place", () => {
+    // The b|c gap reports index 2 when dragging "b" down onto it.
+    expect(adjustMoveIndex({ index: 2, dragIds: ["b"], siblingIds: list })).toBe(1);
+    expect(reorder(list, ["b"], 2)).toEqual(["a", "b", "c"]);
+  });
+
+  test("moving a row to the very bottom lands it last", () => {
+    expect(adjustMoveIndex({ index: 3, dragIds: ["a"], siblingIds: list })).toBe(2);
+    expect(reorder(list, ["a"], 3)).toEqual(["b", "c", "a"]);
+  });
+
+  test("moving a row upward past earlier rows needs no shift", () => {
+    // "c" (index 2) dropped into the a|b gap (index 1): nothing dragged sits
+    // before the slot, so the index is unchanged.
+    expect(adjustMoveIndex({ index: 1, dragIds: ["c"], siblingIds: list })).toBe(1);
+    expect(reorder(list, ["c"], 1)).toEqual(["a", "c", "b"]);
+  });
+
+  test("a row moving in from another parent is not shifted", () => {
+    // The dragged id isn't among the destination siblings, so no removal
+    // happens in this list and the index is used as-is.
+    expect(adjustMoveIndex({ index: 1, dragIds: ["x"], siblingIds: list })).toBe(1);
+  });
+
+  test("multiple dragged rows before the slot each shift the index", () => {
+    const four = ["a", "b", "c", "d"];
+    // Drag "a" and "b" (indices 0 and 1) into the c|d gap (index 3).
+    expect(adjustMoveIndex({ index: 3, dragIds: ["a", "b"], siblingIds: four })).toBe(1);
+    expect(reorder(four, ["a", "b"], 3)).toEqual(["c", "a", "b", "d"]);
+  });
+
+  test("only dragged rows before the slot count", () => {
+    const four = ["a", "b", "c", "d"];
+    // Drag "a" (index 0) and "d" (index 3) to the b|c gap (index 2): only "a"
+    // is before the slot, so shift by 1.
+    expect(adjustMoveIndex({ index: 2, dragIds: ["a", "d"], siblingIds: four })).toBe(1);
+    expect(reorder(four, ["a", "d"], 2)).toEqual(["b", "a", "d", "c"]);
+  });
+
+  test("an index past the end of the sibling list clamps to the end", () => {
+    // 99 clamps to the list length (3); after removing the one dragged row that
+    // precedes the slot, the insertion point is the end of the 2-item result.
+    expect(adjustMoveIndex({ index: 99, dragIds: ["a"], siblingIds: list })).toBe(2);
+    expect(reorder(list, ["a"], 99)).toEqual(["b", "c", "a"]);
+  });
+
+  test("never returns a negative index", () => {
+    expect(adjustMoveIndex({ index: 0, dragIds: ["a"], siblingIds: list })).toBe(0);
+  });
+});

--- a/modules/react-arborist/src/data/adjust-move-index.ts
+++ b/modules/react-arborist/src/data/adjust-move-index.ts
@@ -1,0 +1,43 @@
+/**
+ * Convert the `index` that `onMove` reports into the index to use when your
+ * handler removes the dragged rows *before* inserting them.
+ *
+ * `onMove`'s `index` is a pre-removal slot: it counts positions in the
+ * destination parent's child list as shown on screen, with the dragged rows
+ * still in place. The built-in `SimpleTree.move` / `useSimpleTree` handle this
+ * by inserting before removing, so the index needs no adjustment there. But a
+ * hand-written handler that splices the dragged rows out first — the natural
+ * way to reorder an array — shifts its target one place left for every dragged
+ * row that started before the drop slot. Without correction, dragging a row to
+ * just below itself would jump it past its neighbor (issue #247).
+ *
+ * Pass the destination parent's current child ids in display order (for a
+ * root-level move, that's your top-level data's ids). Ids that aren't among
+ * them — i.e. rows moving in from another parent — don't shift anything.
+ *
+ * @example
+ *   const onMove = ({ dragIds, index }) => {
+ *     const to = adjustMoveIndex({ index, dragIds, siblingIds: data.map((d) => d.id) });
+ *     const dragged = data.filter((d) => dragIds.includes(d.id));
+ *     const rest = data.filter((d) => !dragIds.includes(d.id));
+ *     rest.splice(to, 0, ...dragged);
+ *     setData(rest);
+ *   };
+ */
+export function adjustMoveIndex(args: {
+  index: number;
+  dragIds: string[];
+  siblingIds: string[];
+}): number {
+  const { index, dragIds, siblingIds } = args;
+  const dragging = new Set(dragIds);
+  // `index` is a slot in [0, siblingIds.length]; clamp defensively so an
+  // out-of-range value yields a usable post-removal insertion index on its own
+  // rather than relying on the caller's splice to clamp it.
+  const slot = Math.max(0, Math.min(index, siblingIds.length));
+  let shift = 0;
+  for (let i = 0; i < slot; i++) {
+    if (dragging.has(siblingIds[i])) shift++;
+  }
+  return slot - shift;
+}

--- a/modules/react-arborist/src/index.ts
+++ b/modules/react-arborist/src/index.ts
@@ -9,6 +9,7 @@ export * from "./types/state";
 export * from "./interfaces/node-api";
 export * from "./interfaces/tree-api";
 export * from "./data/simple-tree";
+export { adjustMoveIndex } from "./data/adjust-move-index";
 export * from "./hooks/use-simple-tree";
 export { getTreeLinePrefix } from "./utils";
 export type { TreeLineChars } from "./utils";


### PR DESCRIPTION
## Summary

Addresses the **index** half of #247. That issue reports two distinct bugs — the `onMove` index off-by-one (fixed here) and a separate stale-`parentId` report; this PR does **not** touch `parentId` reporting, so #247 is intentionally left open rather than auto-closed.

`onMove`'s `index` is a **pre-removal slot**: it counts positions in the destination parent's child list _as shown on screen_, with the dragged rows still in place. A hand-written handler that removes the dragged rows before inserting them — the natural way to reorder an array — shifts its target one place left for every dragged row that started before the drop slot. Without correction, **dragging a row to just below itself jumps it past its neighbor**.

`SimpleTree` / `useSimpleTree` avoid this by inserting before removing, so they need no adjustment. But consumers who manage their own data had no clean way to reconcile the index.

This adds an exported helper:

```jsx
import { adjustMoveIndex } from "react-arborist";

const onMove = ({ dragIds, index }) => {
  const to = adjustMoveIndex({ index, dragIds, siblingIds: data.map((d) => d.id) });
  const dragged = data.filter((d) => dragIds.includes(d.id));
  const rest = data.filter((d) => !dragIds.includes(d.id));
  rest.splice(to, 0, ...dragged);
  setData(rest);
};
```

It counts how many dragged ids sit before the drop slot and subtracts that from `index`, returning the index to insert at _after_ removal. Ids not among the destination siblings (rows moving in from another parent) shift nothing.

## Changes

- `adjust-move-index.ts` — the helper, with a JSDoc explanation + usage example.
- Exported from the package index (`index.ts`).
- README section under drag-and-drop documenting the pre-removal index and the helper.
- `adjust-move-index.test.ts` — 9 tests: the core shift cases, an end-to-end `reorder` round-trip mirroring a real `onMove`, cross-parent moves, index-past-end clamping, and never-negative.

## Notes

- The changeset intentionally omits `pr:` — it's now derived at release time (#380). This is the first changeset to rely on that.

## Test plan

- [x] `yarn workspace react-arborist test` — 9 new tests pass (115 total)
- [x] `tsc --noEmit` — clean
- [x] `yarn lint` — 0 warnings/errors
- [x] `yarn fmt:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
