### PR TITLE
Keep the drag destination consistent with canDrop (#247)

### DIFF
--- a/.changes/247-drop-parentid-consistency.md
+++ b/.changes/247-drop-parentid-consistency.md
@@ -1,0 +1,10 @@
+---
+type: fix
+---
+Fixed the drag destination (`willReceiveDrop`, `dragDestinationParent`) reporting
+a parent the cursor forbids. The hover handlers recorded a destination on every
+hover — even where `canDrop()` was false — so dragging a folder toward its own
+subtree left the reported parent pointing at that folder while the cursor said
+"no drop." The consumer-facing destination and the cursor are now both gated on
+`canDrop()` and stay consistent; releasing over an invalid spot is still rejected
+rather than falling back to a root drop (the parentId half of issue #247).

--- a/modules/react-arborist/src/dnd/drop-hook.ts
+++ b/modules/react-arborist/src/dnd/drop-hook.ts
@@ -4,7 +4,6 @@ import { useTreeApi } from "../context";
 import { NodeApi } from "../interfaces/node-api";
 import { DragItem } from "../types/dnd";
 import { computeDrop } from "./compute-drop";
-import { actions as dnd } from "../state/dnd-slice";
 
 export type DropResult = {
   parentId: string | null;
@@ -31,13 +30,7 @@ export function useDropHook(
           prevNode: node.prev,
           nextNode: node.next,
         });
-        if (drop) tree.dispatch(dnd.hovering(drop.parentId, drop.index));
-
-        if (m.canDrop()) {
-          if (cursor) tree.showCursor(cursor);
-        } else {
-          tree.hideCursor();
-        }
+        tree.hover(drop, cursor);
       },
       drop: (_, m) => {
         if (!m.canDrop()) return null;

--- a/modules/react-arborist/src/dnd/outer-drop-hook.ts
+++ b/modules/react-arborist/src/dnd/outer-drop-hook.ts
@@ -3,7 +3,6 @@ import { useTreeApi } from "../context";
 import { DragItem } from "../types/dnd";
 import { computeDrop } from "./compute-drop";
 import { DropResult } from "./drop-hook";
-import { actions as dnd } from "../state/dnd-slice";
 
 export function useOuterDrop() {
   const tree = useTreeApi();
@@ -28,13 +27,7 @@ export function useOuterDrop() {
           prevNode: tree.visibleNodes[tree.visibleNodes.length - 1],
           nextNode: null,
         });
-        if (drop) tree.dispatch(dnd.hovering(drop.parentId, drop.index));
-
-        if (m.canDrop()) {
-          if (cursor) tree.showCursor(cursor);
-        } else {
-          tree.hideCursor();
-        }
+        tree.hover(drop, cursor);
       },
       drop: (_item, m) => {
         if (!m.isOver({ shallow: true })) return null;

--- a/modules/react-arborist/src/interfaces/tree-api.test.ts
+++ b/modules/react-arborist/src/interfaces/tree-api.test.ts
@@ -338,3 +338,61 @@ describe("scrollToOffset / scrollOffset set and read the vertical position (#194
     expect(api.scrollOffset).toBe(0);
   });
 });
+
+describe("tree.hover() keeps the destination consistent with canDrop (#247)", () => {
+  // box(0) > slider(1), folder2(0) > child2(1)
+  const data = [
+    { id: "box", children: [{ id: "slider" }] },
+    { id: "folder2", children: [{ id: "child2" }] },
+  ];
+
+  test("a droppable line hover records the destination and shows the cursor", () => {
+    const api = setupApi({ data });
+    api.dispatch(dnd.dragStart("slider", ["slider"]));
+    // Drop slider as a sibling at the root — a valid line drop.
+    api.hover({ parentId: null, index: 2 }, { type: "line", index: 2, level: 0 });
+    expect(api.canDrop()).toBe(true);
+    expect(api.state.nodes.drag.destinationIndex).toBe(2);
+    expect(api.state.dnd.cursor).toEqual({ type: "line", index: 2, level: 0 });
+  });
+
+  test("a droppable folder hover highlights it via willReceiveDrop", () => {
+    const api = setupApi({ data });
+    api.dispatch(dnd.dragStart("slider", ["slider"]));
+    // Drop slider INTO folder2 (index null → highlight).
+    api.hover({ parentId: "folder2", index: null }, { type: "highlight", id: "folder2" });
+    expect(api.canDrop()).toBe(true);
+    expect(api.willReceiveDrop("folder2")).toBe(true);
+    expect(api.dragDestinationParent?.id).toBe("folder2");
+    expect(api.state.dnd.cursor).toEqual({ type: "highlight", id: "folder2" });
+  });
+
+  test("a can't-drop hover records no destination and hides the cursor", () => {
+    const api = setupApi({ data });
+    // A folder can't be dropped into its own subtree.
+    api.dispatch(dnd.dragStart("box", ["box"]));
+    api.hover({ parentId: "box", index: null }, { type: "highlight", id: "box" });
+
+    expect(api.canDrop()).toBe(false);
+    // The consumer-facing destination and cursor all agree: "no drop here".
+    expect(api.willReceiveDrop("box")).toBe(false);
+    expect(api.dragDestinationParent).toBe(null);
+    expect(api.state.nodes.drag.destinationParentId).toBe(null);
+    expect(api.state.dnd.cursor).toEqual({ type: "none" });
+    // But the drop guard still sees the real target, so a release is rejected
+    // rather than falling back to a root drop.
+    expect(api.state.dnd.parentId).toBe("box");
+  });
+
+  test("moving from a droppable to a can't-drop hover clears the stale destination", () => {
+    const api = setupApi({ data });
+    api.dispatch(dnd.dragStart("box", ["box"]));
+    // Valid: drop box INTO folder2.
+    api.hover({ parentId: "folder2", index: null }, { type: "highlight", id: "folder2" });
+    expect(api.willReceiveDrop("folder2")).toBe(true);
+    // Then slide into box's own subtree, where the drop is invalid.
+    api.hover({ parentId: "box", index: null }, { type: "highlight", id: "box" });
+    expect(api.willReceiveDrop("folder2")).toBe(false);
+    expect(api.dragDestinationParent).toBe(null);
+  });
+});

--- a/modules/react-arborist/src/interfaces/tree-api.ts
+++ b/modules/react-arborist/src/interfaces/tree-api.ts
@@ -18,6 +18,7 @@ import { actions as dnd } from "../state/dnd-slice";
 import { DefaultDragPreview } from "../components/default-drag-preview";
 import { DefaultContainer } from "../components/default-container";
 import { Cursor } from "../dnd/compute-drop";
+import type { DropResult } from "../dnd/drop-hook";
 import { Store } from "redux";
 import { createList } from "../data/create-list";
 import { createIndex } from "../data/create-index";
@@ -570,6 +571,25 @@ export class TreeApi<T> {
       return !isDisabled;
     } else {
       return true;
+    }
+  }
+
+  /* Called by the drop hooks on every hover. Records the computed target for
+     the drop guard (canDrop() and drop() read state.dnd.parentId), then — only
+     when that target is actually droppable — surfaces it to consumers
+     (willReceiveDrop, dragDestinationParent) and shows the cursor. When it
+     isn't droppable, the consumer-facing destination and the cursor are both
+     cleared so they never disagree with canDrop() (#247); the guard still sees
+     the real target, so releasing over an invalid spot is rejected rather than
+     falling back to a root drop. */
+  hover(drop: DropResult | null, cursor: Cursor | null) {
+    if (drop) this.dispatch(dnd.hovering(drop.parentId, drop.index));
+    if (drop && this.canDrop()) {
+      this.dispatch(dnd.setDestination(drop.parentId, drop.index));
+      if (cursor) this.showCursor(cursor);
+    } else {
+      this.dispatch(dnd.setDestination(null, null));
+      this.hideCursor();
     }
   }
 

--- a/modules/react-arborist/src/state/dnd-slice.ts
+++ b/modules/react-arborist/src/state/dnd-slice.ts
@@ -25,6 +25,12 @@ export const actions = {
   hovering(parentId: string | null, index: number | null) {
     return { type: "DND_HOVERING" as const, parentId, index };
   },
+  /* The consumer-facing destination (willReceiveDrop / dragDestinationParent).
+     Dispatched by tree.hover() only when the target is actually droppable, so
+     it never points somewhere canDrop()/the cursor forbids (#247). */
+  setDestination(parentId: string | null, index: number | null) {
+    return { type: "DND_DESTINATION" as const, parentId, index };
+  },
 };
 
 /* Reducer */

--- a/modules/react-arborist/src/state/drag-slice.ts
+++ b/modules/react-arborist/src/state/drag-slice.ts
@@ -28,7 +28,7 @@ export function reducer(
         destinationIndex: null,
         selectedIds: [],
       };
-    case "DND_HOVERING":
+    case "DND_DESTINATION":
       if (action.parentId !== state.destinationParentId || action.index != state.destinationIndex) {
         return {
           ...state,


### PR DESCRIPTION
## Summary

Fixes the **parentId** half of #247 — the stale-destination inconsistency.

Both drop hooks recorded a destination on *every* hover (`dnd.hovering()`), regardless of `canDrop()`, while the cursor was shown **only** when `canDrop()` held. So dragging a folder toward its own subtree left the reported destination pointing at that folder even though the cursor (and `willReceiveDrop`) said "no drop" — exactly the report:

> Cursor and `node.willReceiveDrop` indicate that a drop will **NOT** happen, yet `parentId` is that of the Box.

Confirmed against current `main` before fixing: dragging the internal node into its own subtree left `dragDestinationParent` / `destinationParentId` pointing at it while `canDrop()` and the cursor said otherwise.

## Approach

Centralize the hover glue that both `drop-hook` and `outer-drop-hook` duplicated into a testable **`tree.hover(drop, cursor)`**:

- It records the computed target for the **drop guard** — `canDrop()` and `drop()` still read `state.dnd.parentId`, so an invalid target is correctly rejected.
- It surfaces the **consumer-facing destination** (`willReceiveDrop`, `dragDestinationParent`) and the **cursor** *only when the target is droppable*, via a new `DND_DESTINATION` action the drag slice consumes (previously it followed `DND_HOVERING` unconditionally).
- When not droppable, the destination and cursor are cleared **together**, so they can never disagree with `canDrop()`.

Crucially, this does **not** clear `state.dnd.parentId` to `null` on an invalid hover — doing so would make `canDrop()` re-evaluate against the root and could turn an invalid release into an unintended root drop. The guard keeps seeing the real (rejected) target.

## Why not the index half too

#247 also reports an "index reported as 2 when the cursor implies 1" issue. That's the intended **pre-removal slot** semantics, addressed in #381 (the `adjustMoveIndex` helper + README docs). With the parentId half fixed here, both halves of #247 are now addressed, so this closes it.

Closes #247.

## Test plan

New regression tests in `tree-api.test.ts` driving `tree.hover()` directly — **verified they fail against the pre-fix behavior and pass with the fix**:

- a droppable line hover records the destination + shows the cursor
- a droppable folder hover highlights it (`willReceiveDrop` true)
- **a can't-drop hover records no destination and hides the cursor** (while the drop guard still sees the real target) ← the fix
- **moving from a droppable to a can't-drop hover clears the stale destination** ← the fix

- [x] `yarn workspace react-arborist test` — 110 passed (4 new)
- [x] `tsc --noEmit` — clean
- [x] `yarn lint` — 0 warnings/errors
- [x] `yarn fmt:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)